### PR TITLE
Enhance property calendar UX

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -114,8 +114,8 @@ a:hover, .hover\:text-gold:hover {
   border-radius:1.5rem;
 }
 #calendarGrid button{
-  width:44px;
-  height:44px;
+  width:56px;
+  height:56px;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -128,7 +128,12 @@ a:hover, .hover\:text-gold:hover {
 #calendarGrid button:hover{
   background:#F7E2BB;
 }
-#calendarGrid button.selected{
+#calendarGrid button.range-start,
+#calendarGrid button.range-end{
   background:#232323 !important;
   color:#fff !important;
+}
+#calendarGrid button.in-range{
+  background:#F7E2BB;
+  color:#232323;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -119,7 +119,7 @@ a:hover, .hover\:text-gold:hover {
   display:flex;
   align-items:center;
   justify-content:center;
-  border-radius:9999px;
+  border-radius:0;
   font-weight:600;
   font-size:0.95rem;
   color:#232323;           /* visible by default on white bg */
@@ -132,8 +132,10 @@ a:hover, .hover\:text-gold:hover {
 #calendarGrid button.range-end{
   background:#232323 !important;
   color:#fff !important;
+  border-radius:9999px;
 }
 #calendarGrid button.in-range{
   background:#F7E2BB;
   color:#232323;
+  border-radius:0;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -157,3 +157,15 @@ a:hover, .hover\:text-gold:hover {
   color:#232323;
   border-radius:0;
 }
+
+/* ------- Search bar glass effect ------- */
+.search-field{
+  position:relative;
+  border-radius:0.75rem;
+  transition:background .3s, box-shadow .3s;
+}
+.search-field.glass-active{
+  background:rgba(255,255,255,0.6);
+  backdrop-filter:blur(6px);
+  box-shadow:0 0 0 2px rgba(228,177,101,0.6);
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -127,6 +127,10 @@ a:hover, .hover\:text-gold:hover {
 }
 #calendarGrid button:hover{
   background:#F7E2BB;
+  border-radius:9999px;
+}
+#calendarGrid button.in-range:hover{
+  border-radius:0;
 }
 #calendarGrid button.range-start,
 #calendarGrid button.range-end{

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -130,10 +130,24 @@ a:hover, .hover\:text-gold:hover {
 }
 #calendarGrid button.range-start,
 #calendarGrid button.range-end{
+  position:relative;
   background:#232323 !important;
   color:#fff !important;
   border-radius:9999px;
 }
+#calendarGrid button.range-start::after,
+#calendarGrid button.range-end::after{
+  content:'';
+  position:absolute;
+  top:0;
+  bottom:0;
+  width:50%;
+  background:#F7E2BB;
+  z-index:-1;
+}
+#calendarGrid button.range-start::after{ left:50%; }
+#calendarGrid button.range-end::after{ right:50%; }
+#calendarGrid button.no-after::after{ display:none; }
 #calendarGrid button.in-range{
   background:#F7E2BB;
   color:#232323;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,3 +1,9 @@
+let whereField, checkinField, checkoutField, whoField;
+let searchFields = [];
+function setActiveField(el){
+  searchFields.forEach(f => f?.classList.toggle('glass-active', f===el));
+}
+
 // Mobile Navbar Toggle (if not handled inline)
 document.addEventListener('DOMContentLoaded', function () {
   const btn = document.getElementById('mobile-menu-button');
@@ -21,6 +27,17 @@ document.addEventListener('DOMContentLoaded', function () {
       }, 300);
     });
   });
+
+  /* ------- Search bar glass focus ------- */
+  whereField    = document.getElementById('whereField');
+  checkinField  = document.getElementById('checkinField');
+  checkoutField = document.getElementById('checkoutField');
+  whoField      = document.getElementById('whoField');
+  searchFields  = [whereField, checkinField, checkoutField, whoField];
+
+  const whereInput = document.querySelector('input[name="q"]');
+  whereInput?.addEventListener('focus', ()=> setActiveField(whereField));
+  whereInput?.addEventListener('blur',  ()=> setActiveField(null));
 
   // Brand color hover for anchor tags
   document.querySelectorAll('a').forEach(a => {
@@ -74,7 +91,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const whoCounts    = { adults:0, children:0, infants:0, pets:0 };
 
   window.toggleWhoDropdown = function(){
-    if(whoDropdown) whoDropdown.classList.toggle('hidden');
+    if(!whoDropdown) return;
+    whoDropdown.classList.toggle('hidden');
+    setActiveField(whoDropdown.classList.contains('hidden') ? null : whoField);
   }
 
   window.updateWho = function(type, delta){
@@ -95,6 +114,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if(!whoDropdown || !whoInput) return;
     if(!whoDropdown.contains(e.target) && !whoInput.contains(e.target)){
       whoDropdown.classList.add('hidden');
+      setActiveField(null);
     }
   });
 });
@@ -115,6 +135,7 @@ const calClear       = document.getElementById('calClear');
 let currentMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1); // first of this month
 let startDate = null;
 let endDate   = null;
+let calendarField = null; // 'checkin' or 'checkout'
 
 /* -------- helpers for calendar ---------- */
 const monthNamesFull = ['January','February','March','April','May','June','July',
@@ -196,13 +217,28 @@ function highlightSelection(){
   checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
+
+  if(start && !end){
+    calendarField = 'checkout';
+    setActiveField(checkoutField);
+  }else if(start && end){
+    calendarField = null;
+    setActiveField(null);
+  }else{
+    calendarField = 'checkin';
+    setActiveField(checkinField);
+  }
 }
 
-window.toggleCalendar = function(){
+window.toggleCalendar = function(which){
   if(!calDropdown) return;
+  if(which) calendarField = which;
   calDropdown.classList.toggle('hidden');
   if(!calDropdown.classList.contains('hidden')) {
     renderCalendar();
+    setActiveField(calendarField==='checkout'?checkoutField:checkinField);
+  } else {
+    setActiveField(null);
   }
 }
 
@@ -215,6 +251,7 @@ calClear?.addEventListener('click',()=>{
 });
 calApply?.addEventListener('click',()=>{
   calDropdown.classList.add('hidden');
+  setActiveField(null);
 });
 
 // close when clicking outside
@@ -222,5 +259,6 @@ window.addEventListener('click',e=>{
   if(!calDropdown || calDropdown.classList.contains('hidden')) return;
   if(!calDropdown.contains(e.target) && !checkInInput.contains(e.target) && !checkOutInput.contains(e.target)){
     calDropdown.classList.add('hidden');
+    setActiveField(null);
   }
 });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -128,7 +128,7 @@ function createMonthGrid(dateObj){
   const startWeekD = firstDay.getDay();                        // 0‑6
   const daysInMon  = new Date(y,m+1,0).getDate();             // 28‑31
 
-  let html = `<div class="flex flex-col gap-2"><div class="font-semibold text-[#232323] text-lg text-center">${monthNamesFull[m]} ${y}</div><div class="grid grid-cols-7 gap-2">`;
+  let html = `<div class="flex flex-col gap-2"><div class="font-semibold text-[#232323] text-lg text-center">${monthNamesFull[m]} ${y}</div><div class="grid grid-cols-7 gap-0">`;
   // weekday labels
   weekDays.forEach(d=>{ html += `<div class="font-medium text-gray-400">${d}</div>`; });
   // leading blanks

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -136,7 +136,7 @@ function createMonthGrid(dateObj){
   // days
   for(let d=1; d<=daysInMon; d++){
     const iso = new Date(y,m,d).toISOString().split('T')[0];
-    html += `<button data-date="${iso}">${d}</button>`;
+    html += `<button type="button" data-date="${iso}">${d}</button>`;
   }
   html += '</div></div>';
   return html;
@@ -153,7 +153,8 @@ function renderCalendar(){
 
   // wire up day clicks
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    btn.addEventListener('click',()=>{
+    btn.addEventListener('click',(e)=>{
+      e.preventDefault();
       const iso = btn.dataset.date;
       if(!startDate || (startDate && endDate)){
         startDate = iso;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -177,13 +177,15 @@ function highlightSelection(){
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
     const d = new Date(btn.dataset.date);
-    btn.classList.remove('range-start','range-end','in-range');
+    btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
       btn.classList.add('range-start');
+      if(!end || start.getTime()===end.getTime()) btn.classList.add('no-after');
     }
     if(end && btn.dataset.date===endDate){
       btn.classList.add('range-end');
+      if(!start || start.getTime()===end.getTime()) btn.classList.add('no-after');
     }
     if(start && end && d > start && d < end){
       btn.classList.add('in-range');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -136,8 +136,7 @@ function createMonthGrid(dateObj){
   // days
   for(let d=1; d<=daysInMon; d++){
     const iso = new Date(y,m,d).toISOString().split('T')[0];
-    const active = (startDate && iso===startDate) || (endDate && iso===endDate);
-    html += `<button class="${active?'selected':''}" data-date="${iso}">${d}</button>`;
+    html += `<button data-date="${iso}">${d}</button>`;
   }
   html += '</div></div>';
   return html;
@@ -172,12 +171,28 @@ function renderCalendar(){
 }
 
 function highlightSelection(){
+  const start = startDate ? new Date(startDate) : null;
+  const end   = endDate ? new Date(endDate) : null;
+
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    btn.classList.remove('selected');
-    if(btn.dataset.date===startDate || btn.dataset.date===endDate){
-      btn.classList.add('selected');
+    const d = new Date(btn.dataset.date);
+    btn.classList.remove('range-start','range-end','in-range');
+
+    if(start && btn.dataset.date===startDate){
+      btn.classList.add('range-start');
+    }
+    if(end && btn.dataset.date===endDate){
+      btn.classList.add('range-end');
+    }
+    if(start && end && d > start && d < end){
+      btn.classList.add('in-range');
     }
   });
+
+  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
+  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  calDropdown.dataset.start = startDate || '';
+  calDropdown.dataset.end   = endDate || '';
 }
 
 window.toggleCalendar = function(){
@@ -191,18 +206,11 @@ window.toggleCalendar = function(){
 calPrev?.addEventListener('click',()=>{ currentMonth.setMonth(currentMonth.getMonth()-1); renderCalendar(); });
 calNext?.addEventListener('click',()=>{ currentMonth.setMonth(currentMonth.getMonth()+1); renderCalendar(); });
 calClear?.addEventListener('click',()=>{
-  startDate=null; endDate=null;
-  checkInInput.value='Add dates';
-  checkOutInput.value='Add dates';
-  calDropdown.dataset.start='';
-  calDropdown.dataset.end='';
+  startDate = null;
+  endDate   = null;
   highlightSelection();
 });
 calApply?.addEventListener('click',()=>{
-  if(startDate){ checkInInput.value = new Date(startDate).toLocaleDateString(); }
-  if(endDate){   checkOutInput.value = new Date(endDate).toLocaleDateString(); }
-  calDropdown.dataset.start=startDate||'';
-  calDropdown.dataset.end=endDate||'';
   calDropdown.classList.add('hidden');
 });
 

--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -8,7 +8,7 @@
           class="flex items-center w-full max-w-7xl rounded-full bg-white border border-gray-200 shadow-lg px-4 py-3
                  md:px-8 md:py-4 relative">
       <!-- Where -->
-      <div class="flex-1 flex flex-col justify-center">
+      <div id="whereField" class="search-field flex-1 flex flex-col justify-center">
         <span class="text-base font-bold text-[#232323]">Where</span>
         <input type="text"
                name="q"
@@ -20,25 +20,25 @@
       <div class="mx-2 h-10 w-px bg-gray-200 hidden md:block"></div>
 
       <!-- Check in -->
-      <div class="flex-1 flex flex-col justify-center">
+      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center">
         <span class="text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
                placeholder="Add dates"
                readonly
-               onclick="toggleCalendar()"
+               onclick="toggleCalendar('checkin')"
                class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
       </div>
       <div class="mx-2 h-10 w-px bg-gray-200 hidden md:block"></div>
 
       <!-- Check out -->
-      <div class="flex-1 flex flex-col justify-center">
+      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center">
         <span class="text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
                placeholder="Add dates"
                readonly
-               onclick="toggleCalendar()"
+               onclick="toggleCalendar('checkout')"
                class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
       </div>
 
@@ -64,7 +64,7 @@
       <div class="mx-2 h-10 w-px bg-gray-200 hidden md:block"></div>
 
       <!-- Who -->
-      <div class="relative flex-1 flex flex-col justify-center items-center">
+      <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-center">
         <span class="text-base font-bold text-[#232323]">Who</span>
         <input
           id="whoInput"

--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -44,7 +44,7 @@
 
       <!-- Calendar dropdown -->
       <div id="calendarDropdown"
-           class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[900px] rounded-3xl shadow-2xl bg-white z-50 p-10 hidden border border-gray-100"
+           class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[1050px] rounded-3xl shadow-2xl bg-white z-50 p-10 hidden border border-gray-100"
            data-start=""
            data-end="">
         <div id="calendarHeader" class="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary
- enlarge calendar dropdown width and day buttons
- highlight entire date range with CSS classes
- update calendar logic to behave like Airbnb and keep dropdown open

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68570675bb58832089b7078c89d6357c