### PR TITLE
Add filtering to property search

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -132,3 +132,6 @@ a:hover, .hover\:text-gold:hover {
   background:#232323 !important;
   color:#fff !important;
 }
+#calendarGrid button.in-range{
+  background:#F7E2BB;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -71,6 +71,7 @@ document.addEventListener('DOMContentLoaded', function () {
   /* -------------- Who dropdown -------------- */
   const whoInput     = document.getElementById('whoInput');
   const whoDropdown  = document.getElementById('whoDropdown');
+  const whoHidden    = document.getElementById('guestsHidden');
   const whoCounts    = { adults:0, children:0, infants:0, pets:0 };
 
   window.toggleWhoDropdown = function(){
@@ -88,6 +89,10 @@ document.addEventListener('DOMContentLoaded', function () {
     if(whoCounts.infants)  parts.push(`${whoCounts.infants} infants`);
     if(whoCounts.pets)     parts.push(`${whoCounts.pets} pets`);
     whoInput.value = parts.length ? parts.join(', ') : 'Add guests';
+    if(whoHidden){
+      const total = whoCounts.adults + whoCounts.children + whoCounts.infants + whoCounts.pets;
+      whoHidden.value = total > 0 ? total : '';
+    }
   }
 
   // close on click outside
@@ -199,8 +204,8 @@ calClear?.addEventListener('click',()=>{
   highlightSelection();
 });
 calApply?.addEventListener('click',()=>{
-  if(startDate){ checkInInput.value = new Date(startDate).toLocaleDateString(); }
-  if(endDate){   checkOutInput.value = new Date(endDate).toLocaleDateString(); }
+  if(startDate){ checkInInput.value = startDate; }
+  if(endDate){   checkOutInput.value = endDate; }
   calDropdown.dataset.start=startDate||'';
   calDropdown.dataset.end=endDate||'';
   calDropdown.classList.add('hidden');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -69,13 +69,24 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     }
   /* -------------- Who dropdown -------------- */
+  const searchForm   = document.getElementById('searchForm');
+  const qInput       = document.querySelector('input[name="q"]');
   const whoInput     = document.getElementById('whoInput');
   const whoDropdown  = document.getElementById('whoDropdown');
   const whoHidden    = document.getElementById('guestsHidden');
   const whoCounts    = { adults:0, children:0, infants:0, pets:0 };
 
+  let qTimer;
+  qInput?.addEventListener('input', () => {
+    clearTimeout(qTimer);
+    qTimer = setTimeout(() => searchForm?.submit(), 500);
+  });
+
   window.toggleWhoDropdown = function(){
-    if(whoDropdown) whoDropdown.classList.toggle('hidden');
+    if(!whoDropdown) return;
+    const open = !whoDropdown.classList.contains('hidden');
+    whoDropdown.classList.toggle('hidden');
+    if(open) searchForm?.submit();
   }
 
   window.updateWho = function(type, delta){
@@ -93,6 +104,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const total = whoCounts.adults + whoCounts.children + whoCounts.infants + whoCounts.pets;
       whoHidden.value = total > 0 ? total : '';
     }
+    searchForm?.submit();
   }
 
   // close on click outside
@@ -100,6 +112,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if(!whoDropdown || !whoInput) return;
     if(!whoDropdown.contains(e.target) && !whoInput.contains(e.target)){
       whoDropdown.classList.add('hidden');
+      searchForm?.submit();
     }
   });
 });
@@ -120,6 +133,13 @@ const calClear       = document.getElementById('calClear');
 let currentMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1); // first of this month
 let startDate = null;
 let endDate   = null;
+
+if(calDropdown){
+  startDate = calDropdown.dataset.start || null;
+  endDate   = calDropdown.dataset.end || null;
+  if(startDate) checkInInput.value = startDate;
+  if(endDate)   checkOutInput.value = endDate;
+}
 
 /* -------- helpers for calendar ---------- */
 const monthNamesFull = ['January','February','March','April','May','June','July',
@@ -178,9 +198,13 @@ function renderCalendar(){
 
 function highlightSelection(){
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    btn.classList.remove('selected');
-    if(btn.dataset.date===startDate || btn.dataset.date===endDate){
+    btn.classList.remove('selected','in-range');
+    const iso = btn.dataset.date;
+    if(iso===startDate || iso===endDate){
       btn.classList.add('selected');
+    }
+    if(startDate && endDate && new Date(iso) > new Date(startDate) && new Date(iso) < new Date(endDate)){
+      btn.classList.add('in-range');
     }
   });
 }
@@ -202,6 +226,7 @@ calClear?.addEventListener('click',()=>{
   calDropdown.dataset.start='';
   calDropdown.dataset.end='';
   highlightSelection();
+  searchForm?.submit();
 });
 calApply?.addEventListener('click',()=>{
   if(startDate){ checkInInput.value = startDate; }
@@ -209,6 +234,7 @@ calApply?.addEventListener('click',()=>{
   calDropdown.dataset.start=startDate||'';
   calDropdown.dataset.end=endDate||'';
   calDropdown.classList.add('hidden');
+  searchForm?.submit();
 });
 
 // close when clicking outside
@@ -216,5 +242,6 @@ window.addEventListener('click',e=>{
   if(!calDropdown || calDropdown.classList.contains('hidden')) return;
   if(!calDropdown.contains(e.target) && !checkInInput.contains(e.target) && !checkOutInput.contains(e.target)){
     calDropdown.classList.add('hidden');
+    searchForm?.submit();
   }
 });

--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -4,7 +4,7 @@
 <div class="flex flex-col gap-8">
 
   <div class="flex justify-center mb-10">
-    <form method="get"
+    <form method="get" id="searchForm"
           class="flex items-center w-full max-w-7xl rounded-full bg-white border border-gray-200 shadow-lg px-4 py-3
                  md:px-8 md:py-4 relative">
       <!-- Where -->
@@ -47,8 +47,8 @@
       <!-- Calendar dropdown -->
       <div id="calendarDropdown"
            class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[900px] rounded-3xl shadow-2xl bg-white z-50 p-10 hidden border border-gray-100"
-           data-start=""
-           data-end="">
+           data-start="{{ request.GET.checkin|default_if_none:'' }}"
+           data-end="{{ request.GET.checkout|default_if_none:'' }}">
         <div id="calendarHeader" class="flex items-center justify-between mb-4">
           <button type="button" id="calPrev" class="who-btn-airbnb">&lt;</button>
           <div id="calMonthLabel" class="font-bold text-lg text-[#222]"></div>

--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -24,6 +24,7 @@
         <span class="text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
+               value="{{ request.GET.checkin|default_if_none:'' }}"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar()"
@@ -36,6 +37,7 @@
         <span class="text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
+               value="{{ request.GET.checkout|default_if_none:'' }}"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar()"
@@ -69,13 +71,13 @@
         <input
           id="whoInput"
           type="text"
-          name="guests"
           readonly
-          value="Add guests"
+          value="{{ request.GET.guests|default:'Add guests' }}"
           placeholder="Add guests"
           class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer"
           onclick="toggleWhoDropdown()"
         />
+        <input type="hidden" id="guestsHidden" name="guests" value="{{ request.GET.guests|default:'' }}" />
 
         <!-- Dropdown -->
         <div id="whoDropdown"


### PR DESCRIPTION
## Summary
- handle new query parameters in `property_list`
- keep guest/bedroom selections in the search form
- return selected check-in and check-out dates
- send numeric guest counts via a hidden field
- store selected dates as ISO strings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6857761ea8a483208aacb16c16493345