### PR TITLE
Fix root login route

### DIFF
--- a/gip_web/urls.py
+++ b/gip_web/urls.py
@@ -15,10 +15,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path,include
+from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -26,6 +26,7 @@ urlpatterns = [
     path('properties/', include('properties.urls', namespace='properties')),
     path('admin-panel/', include('admin_panel.urls')),
     path('accounts/', include('accounts.urls')),
+    path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- make login page available at `/login/`

## Testing
- `python manage.py test`
- `python manage.py check`
- `curl -I http://127.0.0.1:8000/login/`

------
https://chatgpt.com/codex/tasks/task_e_6858224a0c8883208d79dc15dd60052e