### PR TITLE
Fix navbar username icon

### DIFF
--- a/templates/includes/navbar.html
+++ b/templates/includes/navbar.html
@@ -29,10 +29,7 @@
       <!-- Profile/Login Button -->
       <div class="hidden md:flex items-center space-x-6">
         {% if user.is_authenticated %}
-          <a href="/profile/" class="flex items-center space-x-3 group">
-            <span class="inline-block w-9 h-9 bg-gold rounded-full flex items-center justify-center shadow">
-              <svg class="w-6 h-6 text-[#232323]" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A9 9 0 1112 21a9 9 0 01-6.879-3.196z"></path></svg>
-            </span>
+          <a href="/profile/" class="flex items-center group">
             <span class="text-white group-hover:text-gold font-semibold text-lg">{{ user.username }}</span>
           </a>
           <a href="/logout/" class="text-gold hover:text-[#EFCB89] font-semibold transition">Logout</a>


### PR DESCRIPTION
## Summary
- simplify profile link in navbar by removing gold circle icon

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68583f8973348320a6dcd90bd61c96ba