### PR TITLE
Implement user profile edit page

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,23 @@
+from django import forms
+from django.contrib.auth.forms import PasswordChangeForm
+from .models import User
+
+class UserUpdateForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = [
+            'first_name',
+            'last_name',
+            'username',
+            'email',
+            'phone_number',
+            'profile_photo',
+        ]
+        widgets = {
+            'first_name': forms.TextInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
+            'last_name': forms.TextInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
+            'username': forms.TextInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
+            'email': forms.EmailInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
+            'phone_number': forms.TextInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
+            'profile_photo': forms.ClearableFileInput(attrs={'class': 'block w-full text-sm text-white border border-gold rounded-md cursor-pointer bg-[#1f1f1f] focus:outline-none'}),
+        }

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.contrib.auth.forms import PasswordChangeForm
 from .models import User
 
 class UserUpdateForm(forms.ModelForm):
@@ -19,5 +18,5 @@ class UserUpdateForm(forms.ModelForm):
             'username': forms.TextInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
             'email': forms.EmailInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
             'phone_number': forms.TextInput(attrs={'class': 'appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border border-gold rounded-md text-white focus:outline-none focus:ring-gold focus:border-gold sm:text-sm'}),
-            'profile_photo': forms.ClearableFileInput(attrs={'class': 'block w-full text-sm text-white border border-gold rounded-md cursor-pointer bg-[#1f1f1f] focus:outline-none'}),
+            'profile_photo': forms.FileInput(attrs={'class': 'hidden', 'accept': 'image/*'}),
         }

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,4 +6,6 @@ urlpatterns = [
     path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     path('logout/', views.logout_view, name='logout'),
     path('profile/', views.profile_view, name='profile'),
+    path('profile/edit/', views.edit_profile, name='edit_profile'),
+    path('password-change/', views.CustomPasswordChangeView.as_view(), name='password_change'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,10 @@
 from django.shortcuts import redirect, render
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.urls import reverse_lazy
+from django.contrib.auth.views import PasswordChangeView
+from .forms import UserUpdateForm
 
 
 def logout_view(request):
@@ -15,3 +19,19 @@ def profile_view(request):
     """Display the logged in user's profile."""
     return render(request, 'accounts/profile.html')
 
+@login_required
+def edit_profile(request):
+    user = request.user
+    if request.method == 'POST':
+        form = UserUpdateForm(request.POST, request.FILES, instance=user)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Profile updated successfully.")
+            return redirect('profile')
+    else:
+        form = UserUpdateForm(instance=user)
+    return render(request, 'accounts/edit_profile.html', {'form': form})
+
+class CustomPasswordChangeView(PasswordChangeView):
+    template_name = 'accounts/password_change.html'
+    success_url = reverse_lazy('profile')

--- a/gip_web/urls.py
+++ b/gip_web/urls.py
@@ -19,7 +19,7 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
-from accounts.views import logout_view, profile_view
+from accounts.views import logout_view, profile_view, edit_profile, CustomPasswordChangeView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -28,6 +28,8 @@ urlpatterns = [
     path('admin-panel/', include('admin_panel.urls')),
     path('accounts/', include('accounts.urls')),
     path('profile/', profile_view, name='profile'),
+    path('profile/edit/', edit_profile, name='edit_profile'),
+    path('password-change/', CustomPasswordChangeView.as_view(), name='password_change'),
     path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     path('logout/', logout_view, name='logout'),
 ]

--- a/templates/accounts/edit_profile.html
+++ b/templates/accounts/edit_profile.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="min-h-screen flex items-start justify-center pt-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full bg-gip border-2 border-gold p-8 rounded-xl shadow-xl">
+    <h2 class="text-center text-2xl font-extrabold text-gold mb-6">Edit Profile</h2>
+    {% if messages %}
+      <ul class="mb-4">
+        {% for message in messages %}
+          <li class="text-green-500">{{ message }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    <form method="post" enctype="multipart/form-data" class="space-y-4">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div>
+        <label class="block text-sm font-medium text-gold" for="id_first_name">First name</label>
+        {{ form.first_name }}
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gold" for="id_last_name">Last name</label>
+        {{ form.last_name }}
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gold" for="id_username">Username</label>
+        {{ form.username }}
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gold" for="id_email">Email</label>
+        {{ form.email }}
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gold" for="id_phone_number">Phone number</label>
+        {{ form.phone_number }}
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gold" for="id_profile_photo">Profile photo</label>
+        {{ form.profile_photo }}
+      </div>
+      <div class="flex justify-between items-center">
+        <button type="submit" class="button-gold">Save</button>
+        <a href="{% url 'password_change' %}" class="text-gold hover:text-[#EFCB89]">Change Password</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/accounts/edit_profile.html
+++ b/templates/accounts/edit_profile.html
@@ -12,10 +12,16 @@
         {% endfor %}
       </ul>
     {% endif %}
-    <form method="post" enctype="multipart/form-data" class="space-y-4">
+    <form method="post" enctype="multipart/form-data" class="space-y-4 text-center">
       {% csrf_token %}
       {{ form.non_field_errors }}
-      <div>
+      <div class="flex justify-center mb-4">
+        <label for="id_profile_photo" class="cursor-pointer inline-block">
+          <img id="profile-preview" src="{{ user.profile_photo_url }}" alt="Profile photo" class="w-32 h-32 rounded-full object-cover border-2 border-gold" />
+        </label>
+        {{ form.profile_photo }}
+      </div>
+      <div class="text-left">
         <label class="block text-sm font-medium text-gold" for="id_first_name">First name</label>
         {{ form.first_name }}
       </div>
@@ -35,10 +41,6 @@
         <label class="block text-sm font-medium text-gold" for="id_phone_number">Phone number</label>
         {{ form.phone_number }}
       </div>
-      <div>
-        <label class="block text-sm font-medium text-gold" for="id_profile_photo">Profile photo</label>
-        {{ form.profile_photo }}
-      </div>
       <div class="flex justify-between items-center">
         <button type="submit" class="button-gold">Save</button>
         <a href="{% url 'password_change' %}" class="text-gold hover:text-[#EFCB89]">Change Password</a>
@@ -46,4 +48,16 @@
     </form>
   </div>
 </div>
+<script>
+  const input = document.getElementById('id_profile_photo');
+  const preview = document.getElementById('profile-preview');
+  if(input && preview){
+    input.addEventListener('change', e => {
+      const [file] = input.files;
+      if(file){
+        preview.src = URL.createObjectURL(file);
+      }
+    });
+  }
+</script>
 {% endblock %}

--- a/templates/accounts/password_change.html
+++ b/templates/accounts/password_change.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="min-h-screen flex items-start justify-center pt-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full bg-gip border-2 border-gold p-8 rounded-xl shadow-xl">
+    <h2 class="text-center text-2xl font-extrabold text-gold mb-6">Change Password</h2>
+    <form method="post" class="space-y-4">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <div class="flex justify-between items-center">
+        <button type="submit" class="button-gold">Update Password</button>
+        <a href="{% url 'profile' %}" class="text-gold hover:text-[#EFCB89]">Back to Profile</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -39,7 +39,7 @@
             {{ user.role|capfirst }}
           </p>
         {% endif %}
-        <a href="{% url 'admin:accounts_user_change' user.id %}" class="inline-block mt-6 button-gold px-6 py-2">Edit Profile</a>
+        <a href="{% url 'edit_profile' %}" class="inline-block mt-6 button-gold px-6 py-2">Edit Profile</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enable editing user data in accounts app with a new `UserUpdateForm`
- add views for editing profiles and changing passwords
- wire new URLs in `accounts.urls` and project URLs
- create templates for editing profile and password change
- link profile page to the new edit screen

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685845fc075883208066b19f7421a9c9