### PR TITLE
Add user registration view

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,29 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from .models import User
+
+class UserRegistrationForm(UserCreationForm):
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = (
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "profile_photo",
+            "role",
+            "position",
+            "phone_number",
+            "password1",
+            "password2",
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        css_class = (
+            "appearance-none block w-full px-3 py-2 bg-[#1f1f1f] border "
+            "border-gold rounded-md placeholder-gray-400 text-white "
+            "focus:outline-none focus:ring-gold focus:border-gold sm:text-sm"
+        )
+        for field in self.fields.values():
+            field.widget.attrs.setdefault("class", css_class)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,5 +5,6 @@ from . import views
 urlpatterns = [
     path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     path('logout/', views.logout_view, name='logout'),
+    path('register/', views.register_view, name='register'),
     path('profile/', views.profile_view, name='profile'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import redirect, render
-from django.contrib.auth import logout
+from django.contrib.auth import logout, login
 from django.contrib.auth.decorators import login_required
+
+from .forms import UserRegistrationForm
 
 
 def logout_view(request):
@@ -14,4 +16,17 @@ def logout_view(request):
 def profile_view(request):
     """Display the logged in user's profile."""
     return render(request, 'accounts/profile.html')
+
+
+def register_view(request):
+    """Handle user registration and log the user in when successful."""
+    if request.method == "POST":
+        form = UserRegistrationForm(request.POST, request.FILES)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return redirect("profile")
+    else:
+        form = UserRegistrationForm()
+    return render(request, "accounts/register.html", {"form": form})
 

--- a/gip_web/urls.py
+++ b/gip_web/urls.py
@@ -19,7 +19,7 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
-from accounts.views import logout_view, profile_view
+from accounts.views import logout_view, profile_view, register_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -28,6 +28,7 @@ urlpatterns = [
     path('admin-panel/', include('admin_panel.urls')),
     path('accounts/', include('accounts.urls')),
     path('profile/', profile_view, name='profile'),
+    path('register/', register_view, name='register'),
     path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     path('logout/', logout_view, name='logout'),
 ]

--- a/templates/accounts/register.html
+++ b/templates/accounts/register.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="min-h-screen flex items-start justify-center pt-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full bg-gip border-2 border-gold p-8 rounded-xl shadow-xl">
+    <div class="flex flex-col items-center mb-6">
+      <img src="{% static 'images/logo.jpeg' %}" alt="Logo" class="w-20 h-20 rounded-full shadow-md mb-2">
+      <h2 class="mt-2 text-center text-2xl font-extrabold text-gold">Register</h2>
+    </div>
+    <form method="post" enctype="multipart/form-data" class="space-y-6">
+      {% csrf_token %}
+      {% for field in form %}
+        <div>
+          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-gold">{{ field.label }}</label>
+          {{ field }}
+          {% if field.help_text %}<p class="text-xs text-gray-400">{{ field.help_text }}</p>{% endif %}
+          {% for error in field.errors %}<p class="text-red-600 text-sm">{{ error }}</p>{% endfor %}
+        </div>
+      {% endfor %}
+      <div>
+        <button type="submit" class="w-full flex justify-center py-2 px-4 button-gold text-[#232323] rounded-md shadow-md hover:shadow-lg focus:outline-none">Register</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow visitors to create accounts
- add a registration form and template
- route `/register/` through project and accounts apps

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685863526b58832080c9d66db7b4bc22