### PR TITLE
Rename staff role to user

### DIFF
--- a/accounts/migrations/0004_rename_staff_to_user.py
+++ b/accounts/migrations/0004_rename_staff_to_user.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+def forwards_func(apps, schema_editor):
+    User = apps.get_model("accounts", "User")
+    User.objects.filter(role="staff").update(role="user")
+
+
+def backwards_func(apps, schema_editor):
+    User = apps.get_model("accounts", "User")
+    User.objects.filter(role="user").update(role="staff")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0003_add_extra_fields"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="user",
+            name="role",
+            field=models.CharField(
+                choices=[
+                    ("superadmin", "Super Admin"),
+                    ("admin", "Admin"),
+                    ("user", "User"),
+                ],
+                default="user",
+                max_length=20,
+            ),
+        ),
+        migrations.RunPython(forwards_func, backwards_func),
+    ]

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -6,7 +6,7 @@ from django.templatetags.static import static
 USER_ROLES = [
     ('superadmin', 'Super Admin'),
     ('admin', 'Admin'),
-    ('staff', 'Staff'),
+    ('user', 'User'),
 ]
 
 def user_avatar_path(instance, filename):
@@ -16,7 +16,7 @@ def user_avatar_path(instance, filename):
 class User(AbstractUser):
     # Add extra fields for your custom user
     profile_photo = models.ImageField(upload_to=user_avatar_path, blank=True, null=True)
-    role = models.CharField(max_length=20, choices=USER_ROLES, default='staff')
+    role = models.CharField(max_length=20, choices=USER_ROLES, default='user')
     position = models.CharField(max_length=100, blank=True, null=True)
     phone_number = models.CharField(max_length=20, blank=True, null=True)
     date_of_birth = models.DateField(blank=True, null=True)

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -22,7 +22,7 @@
           {{ user.position }}
         </p>
         {% endif %}
-        {% if user.role == 'staff' %}
+        {% if user.role == 'user' %}
           {% if user.phone_number %}
           <p class="flex items-center gap-2 text-gray-700">
             <svg class="w-5 h-5 text-gold" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- rename `staff` role to `user`
- update profile template to check for the new role name
- migrate existing users to the new role

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6858bbbc43f88320a5df575a2dcb3315