### PR TITLE
Add manage page access for admins

### DIFF
--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -1,11 +1,24 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.shortcuts import render
+from accounts.models import User
+from properties.models import Property, Booking
 
 def is_admin_or_superadmin(user):
-    return user.is_authenticated and (getattr(user, 'is_admin', False) or getattr(user, 'is_superadmin', False))
+    """Return True if the user has admin privileges."""
+    return user.is_authenticated and (
+        getattr(user, 'is_admin', False)
+        or getattr(user, 'is_superadmin', False)
+        or user.is_superuser
+    )
 
 @login_required
 @user_passes_test(is_admin_or_superadmin)
 def dashboard(request):
-    # You can add stats or context here
-    return render(request, 'admin_panel/dashboard.html')
+    """Render the management dashboard with some basic statistics."""
+    context = {
+        'properties_count': Property.objects.count(),
+        'bookings_count': Booking.objects.count(),
+    }
+    if request.user.is_superadmin or request.user.is_superuser:
+        context['users_count'] = User.objects.count()
+    return render(request, 'admin_panel/dashboard.html', context)

--- a/gip_web/urls.py
+++ b/gip_web/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('core.urls')),
     path('properties/', include('properties.urls', namespace='properties')),
+    path('manage/', include('admin_panel.urls')),
     path('admin-panel/', include('admin_panel.urls')),
     path('accounts/', include('accounts.urls')),
     path('profile/', profile_view, name='profile'),

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -40,6 +40,9 @@
           </p>
         {% endif %}
         <a href="{% url 'edit_profile' %}" class="inline-block mt-6 button-gold px-6 py-2">Edit Profile</a>
+        {% if user.is_admin or user.is_superadmin or user.is_superuser %}
+        <a href="{% url 'admin_panel_dashboard' %}" class="inline-block mt-2 button-gold px-6 py-2">Manage</a>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow superusers, admins, and superadmins to access dashboard
- expose `/manage/` route for management dashboard
- show **Manage** button on privileged users' profile page
- display basic statistics on dashboard

## Testing
- `python -m pip install -q -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6858d332495883209bbf1fd79b488d74