### PR TITLE
Improve photo management for property creation

### DIFF
--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -114,8 +114,15 @@
       </div>
       {% endif %}
       <div>
-        <label for="id_photos" class="block text-sm font-medium text-gold">Photos</label>
-        {{ form.photos }}
+        <label class="block text-sm font-medium text-gold">Photos</label>
+        <div class="hidden">{{ form.photos }}</div>
+        {{ form.photo_order }}
+        <button id="addPhotosBtn" type="button" class="button-gold px-4 py-2 rounded-md mb-2">Add Photos</button>
+        <div id="photoPreview" class="grid grid-cols-3 gap-2"></div>
+        <div id="photoOverlay" class="fixed inset-0 bg-black bg-opacity-80 hidden items-center justify-center z-30">
+          <button id="overlayClose" type="button" class="absolute top-4 right-4 text-white text-3xl">&times;</button>
+          <div id="overlayContent" class="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-[90vh] overflow-y-auto p-4"></div>
+        </div>
         {% for error in form.photos.errors %}
           <p class="text-red-500 text-sm">{{ error }}</p>
         {% endfor %}
@@ -129,6 +136,7 @@
 
 {% block extra_js %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script>
   const map = L.map('map').setView([36.7213, -4.4217], 12);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -190,6 +198,58 @@
     }
   });
   updateFacilities();
+
+  /* ---------- Photo upload preview & ordering ---------- */
+  const photoInput = document.getElementById('id_photos');
+  const addPhotosBtn = document.getElementById('addPhotosBtn');
+  const preview = document.getElementById('photoPreview');
+  const orderInput = document.getElementById('id_photo_order');
+
+  addPhotosBtn?.addEventListener('click', () => photoInput?.click());
+
+  function updateOrder() {
+    const indices = Array.from(preview.children).map(el => el.dataset.index);
+    if (orderInput) orderInput.value = indices.join(',');
+  }
+
+  photoInput?.addEventListener('change', () => {
+    preview.innerHTML = '';
+    Array.from(photoInput.files).forEach((file, idx) => {
+      const reader = new FileReader();
+      reader.onload = e => {
+        const div = document.createElement('div');
+        div.className = 'cursor-move aspect-square overflow-hidden rounded-md';
+        div.dataset.index = idx;
+        div.innerHTML = `<img src="${e.target.result}" class="object-cover w-full h-full"/>`;
+        preview.appendChild(div);
+        updateOrder();
+      };
+      reader.readAsDataURL(file);
+    });
+  });
+
+  if (window.Sortable) {
+    Sortable.create(preview, {
+      animation: 150,
+      onUpdate: updateOrder
+    });
+  }
+
+  const overlay = document.getElementById('photoOverlay');
+  const overlayClose = document.getElementById('overlayClose');
+  const overlayContent = document.getElementById('overlayContent');
+
+  preview.addEventListener('click', () => {
+    overlayContent.innerHTML = preview.innerHTML;
+    overlay.classList.remove('hidden');
+  });
+
+  overlayClose.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+  });
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) overlay.classList.add('hidden');
+  });
 </script>
 {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `photo_order` hidden field to allow custom image ordering
- build sortable gallery in add property page
- load SortableJS and handle preview, ordering and overlay display
- save uploaded photos in specified order

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685ee2b5f758832095ef3d3b62715ab9