### PR TITLE
Fix add property media upload

### DIFF
--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -114,22 +114,15 @@
       </div>
       {% endif %}
       <div>
-        <label for="id_photos" class="block text-sm font-medium text-gold">Photos</label>
+        <label for="id_photos" class="block text-sm font-medium text-gold">Photos / Videos</label>
         {{ form.photos }}
-        <button id="addPhotosBtn" type="button" class="button-gold mb-2">Insert Photos</button>
+        <button id="addPhotosBtn" type="button" class="button-gold mb-2">Insert Media</button>
         <div id="photoGallery" class="grid grid-cols-3 gap-2"></div>
         <div id="photoModal" class="fixed inset-0 bg-black bg-opacity-80 hidden items-center justify-center z-50">
           <button id="closePhotoModal" type="button" class="absolute top-4 right-4 text-white text-2xl">&times;</button>
           <img id="photoModalImg" class="max-h-full max-w-full object-contain" />
         </div>
         {% for error in form.photos.errors %}
-          <p class="text-red-500 text-sm">{{ error }}</p>
-        {% endfor %}
-      </div>
-      <div>
-        <label for="id_videos" class="block text-sm font-medium text-gold">Videos</label>
-        {{ form.videos }}
-        {% for error in form.videos.errors %}
           <p class="text-red-500 text-sm">{{ error }}</p>
         {% endfor %}
       </div>
@@ -173,13 +166,6 @@
   map.on('click', e => setLocation(e.latlng));
   window.addEventListener('load', () => {
     map.invalidateSize();
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(pos => {
-        const here = { lat: pos.coords.latitude, lng: pos.coords.longitude };
-        map.setView([here.lat, here.lng], 13);
-        setLocation(here);
-      });
-    }
   });
 
   const facBtn = document.getElementById('facilitiesButton');
@@ -212,7 +198,7 @@
   const modal        = document.getElementById('photoModal');
   const modalImg     = document.getElementById('photoModalImg');
   const closeModal   = document.getElementById('closePhotoModal');
-  let photoFiles = [];
+  let mediaFiles = [];
 
   if(photoInput) photoInput.classList.add('hidden');
 
@@ -220,24 +206,28 @@
 
   photoInput?.addEventListener('change', () => {
     if (!photoInput.files) return;
-    photoFiles.push(...photoInput.files);
+    mediaFiles.push(...photoInput.files);
     photoInput.value = '';
     renderGallery();
   });
 
   function renderGallery(){
     gallery.innerHTML = '';
-    photoFiles.forEach((file, idx) => {
+    mediaFiles.forEach((file, idx) => {
       const url = URL.createObjectURL(file);
       const div = document.createElement('div');
       div.className = 'relative';
       div.dataset.index = idx;
-      div.innerHTML = `<img src="${url}" class="w-full h-24 object-cover rounded cursor-pointer">`;
+      if(file.type.startsWith('image')){
+        div.innerHTML = `<img src="${url}" class="w-full h-24 object-cover rounded cursor-pointer">`;
+        div.addEventListener('click', () => {
+          modalImg.src = url;
+          modal.classList.remove('hidden');
+        });
+      }else if(file.type.startsWith('video')){
+        div.innerHTML = `<video class="w-full h-24 object-cover rounded" src="${url}" muted></video>`;
+      }
       gallery.appendChild(div);
-      div.addEventListener('click', () => {
-        modalImg.src = url;
-        modal.classList.remove('hidden');
-      });
     });
   }
 
@@ -245,9 +235,9 @@
     const ordered = [];
     gallery.querySelectorAll('div').forEach(div => {
       const idx = parseInt(div.dataset.index, 10);
-      if(!isNaN(idx)) ordered.push(photoFiles[idx]);
+      if(!isNaN(idx)) ordered.push(mediaFiles[idx]);
     });
-    photoFiles = ordered;
+    mediaFiles = ordered;
     gallery.querySelectorAll('div').forEach((div, i) => div.dataset.index = i);
   }
 
@@ -266,7 +256,7 @@
 
   document.querySelector('form')?.addEventListener('submit', () => {
     const dt = new DataTransfer();
-    photoFiles.forEach(f => dt.items.add(f));
+    mediaFiles.forEach(f => dt.items.add(f));
     if(photoInput) photoInput.files = dt.files;
   });
 </script>


### PR DESCRIPTION
## Summary
- handle videos in the photos field and drop separate video input
- remove automatic geolocation popup when opening add-property page
- support video preview in the gallery

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fb12c497883208d975ffb6fb0fb27