### PR TITLE
Add Terms of Service page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('about/', views.about, name='about'),
     path('contact/', views.contact, name='contact'),
+    path('terms/', views.terms, name='terms'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -13,3 +13,7 @@ def about(request):
 
 def contact(request):
     return render(request, "core/contact.html")
+
+def terms(request):
+    """Display the Terms of Service page."""
+    return render(request, "core/terms.html")

--- a/templates/core/terms.html
+++ b/templates/core/terms.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="bg-[#232323] text-white rounded-3xl shadow-xl mb-16">
+  <div class="container mx-auto px-4 py-20 text-center">
+    <h1 class="text-5xl font-extrabold mb-4 text-gold">Terms of Service</h1>
+    <p class="text-xl opacity-90 mb-8 max-w-2xl mx-auto text-secondary">
+      Please read these terms carefully before using our website.
+    </p>
+  </div>
+</section>
+<section class="max-w-3xl mx-auto bg-white text-[#232323] p-8 rounded-2xl shadow-lg space-y-4">
+  <p>By accessing this site you agree to be bound by these terms of service and all applicable laws and regulations.</p>
+  <p>All content provided is for informational purposes only and may be changed or updated without notice.</p>
+  <p>We are not liable for any damages arising from the use of this site.</p>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a simple Terms of Service page
- hook up new URL and view in the core app

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fb24a261c8320895b35740768867a