### PR TITLE
Add terms of service page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('about/', views.about, name='about'),
     path('contact/', views.contact, name='contact'),
+    path('terms/', views.terms, name='terms'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -13,3 +13,6 @@ def about(request):
 
 def contact(request):
     return render(request, "core/contact.html")
+
+def terms(request):
+    return render(request, "core/terms.html")

--- a/templates/core/terms.html
+++ b/templates/core/terms.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="bg-[#232323] text-white rounded-3xl shadow-xl mb-16">
+  <div class="container mx-auto px-4 py-20 text-center">
+    <h1 class="text-5xl font-extrabold mb-4 text-gold">Terms of Service</h1>
+    <p class="text-xl opacity-90 mb-8 max-w-2xl mx-auto text-secondary">
+      By using this website, you agree to the following terms and conditions.
+    </p>
+  </div>
+</section>
+<section class="max-w-4xl mx-auto space-y-6 bg-white text-[#232323] p-8 rounded-2xl shadow-lg">
+  <p>
+    The content provided on this site is for informational purposes only.
+    We strive to keep information accurate and up to date, but make no
+    warranties regarding its completeness or suitability for any purpose.
+  </p>
+  <p>
+    All materials on this website are the property of Group Ideal Primer
+    unless otherwise stated. You may not reproduce, distribute, or create
+    derivative works without our explicit consent.
+  </p>
+  <p>
+    Your continued use of this site constitutes acceptance of these terms.
+    We reserve the right to modify them at any time.
+  </p>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- route `/terms/` to a new template
- implement `terms` view
- create the terms of service page

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_685fb24a261c8320895b35740768867a