### PR TITLE
Add terms of service page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('about/', views.about, name='about'),
     path('contact/', views.contact, name='contact'),
+    path('terms/', views.terms, name='terms'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -13,3 +13,6 @@ def about(request):
 
 def contact(request):
     return render(request, "core/contact.html")
+
+def terms(request):
+    return render(request, "core/terms.html")

--- a/templates/core/terms.html
+++ b/templates/core/terms.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="bg-[#232323] text-white rounded-3xl shadow-xl mb-16">
+  <div class="container mx-auto px-4 py-20 text-center">
+    <h1 class="text-5xl font-extrabold mb-4 text-gold">Terms of Service</h1>
+    <p class="text-xl opacity-90 mb-8 max-w-2xl mx-auto text-secondary">
+      The following terms govern your use of this website.
+    </p>
+  </div>
+</section>
+<section class="max-w-4xl mx-auto text-secondary">
+  <h2 class="text-xl font-bold mb-4 text-gold">1. Acceptance of Terms</h2>
+  <p class="mb-4">By accessing or using this site, you agree to comply with these Terms of Service and all applicable laws and regulations.</p>
+  <h2 class="text-xl font-bold mb-4 text-gold">2. Use License</h2>
+  <p class="mb-4">Permission is granted to temporarily download one copy of the materials on this website for personal, non-commercial viewing only. This is the grant of a license, not a transfer of title.</p>
+  <h2 class="text-xl font-bold mb-4 text-gold">3. Disclaimer</h2>
+  <p class="mb-4">The materials on our website are provided on an "as is" basis. We make no warranties, expressed or implied.</p>
+  <h2 class="text-xl font-bold mb-4 text-gold">4. Limitations</h2>
+  <p class="mb-4">In no event shall Group Ideal Primer be liable for any damages arising out of the use or inability to use the materials on this site.</p>
+  <h2 class="text-xl font-bold mb-4 text-gold">5. Modifications</h2>
+  <p class="mb-4">We may revise these Terms of Service at any time without notice. By using this website you are agreeing to be bound by the then-current version of these terms.</p>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Terms of Service template
- add view and URL mapping for `/terms/`

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fb24a261c8320895b35740768867a