### PR TITLE
Add terms of service page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('about/', views.about, name='about'),
     path('contact/', views.contact, name='contact'),
+    path('terms/', views.terms, name='terms'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -13,3 +13,7 @@ def about(request):
 
 def contact(request):
     return render(request, "core/contact.html")
+
+def terms(request):
+    """Display the terms of service page."""
+    return render(request, "core/terms.html")

--- a/templates/core/terms.html
+++ b/templates/core/terms.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="bg-[#232323] text-white rounded-3xl shadow-xl mb-16">
+  <div class="container mx-auto px-4 py-20 text-center">
+    <h1 class="text-5xl font-extrabold mb-4 text-gold">Terms of Service</h1>
+    <p class="text-xl opacity-90 mb-8 max-w-2xl mx-auto text-secondary">
+      These terms govern your use of the Group Ideal Primer website. Please read them carefully.
+    </p>
+  </div>
+</section>
+<section class="max-w-4xl mx-auto space-y-6 text-[#232323] bg-white p-8 rounded-2xl shadow">
+  <h2 class="text-2xl font-bold text-gold">1. Acceptance of Terms</h2>
+  <p>By accessing this site, you agree to comply with these terms and all applicable laws.</p>
+  <h2 class="text-2xl font-bold text-gold">2. Use of Content</h2>
+  <p>Content on this site is for informational purposes only. You may not copy or redistribute without permission.</p>
+  <h2 class="text-2xl font-bold text-gold">3. Liability</h2>
+  <p>We strive to keep information accurate but make no warranties. Your use of the site is at your own risk.</p>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a route and view for `/terms/`
- create the terms of service template
- include the new page in URLconf

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fb24a261c8320895b35740768867a