### PR TITLE
Fix search bar visibility

### DIFF
--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -3,6 +3,7 @@
 
 <div class="flex flex-col gap-8">
 
+  {% if filter_type == 'short-term' %}
   <div class="flex justify-center mb-10">
     <form method="get"
           class="flex items-center w-full max-w-7xl rounded-full bg-white border border-gray-200 shadow-lg px-4 py-3
@@ -147,6 +148,7 @@
       </button>
     </form>
   </div>
+  {% endif %}
 
   <!-- Tabs for Property Types -->
   <div class="flex flex-wrap gap-3 mb-6 justify-center">


### PR DESCRIPTION
## Summary
- show the search bar only when viewing short‑term properties

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fb2d4a4b48320b2e115719a636bbe