### PR TITLE
Add admin panel property templates

### DIFF
--- a/templates/admin_panel/confirm_delete.html
+++ b/templates/admin_panel/confirm_delete.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-md mx-auto bg-gip border border-gold rounded-xl p-6 text-center">
+  <h1 class="text-2xl font-bold text-gold mb-4">Confirm Deletion</h1>
+  <p class="mb-6">Are you sure you want to delete "{{ object }}"?</p>
+  <form method="post">
+    {% csrf_token %}
+    <div class="flex justify-center gap-4">
+      <button type="submit" class="button-gold px-4 py-2 text-[#232323]">Yes, delete</button>
+      <a href="{{ cancel_url }}" class="button-gold px-4 py-2 text-[#232323]">Cancel</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/admin_panel/property_list.html
+++ b/templates/admin_panel/property_list.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto">
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold text-gold">Properties</h1>
+    <a href="{% url 'add_property' %}" class="button-gold px-4 py-2 rounded-md text-[#232323]">Add Property</a>
+  </div>
+  <div class="overflow-x-auto bg-gip border border-gold rounded-lg">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-[#1f1f1f] text-gold">
+        <tr>
+          <th class="px-4 py-2 text-left text-sm font-semibold">Name</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold">Type</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold">Location</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200">
+        {% for property in properties %}
+        <tr class="hover:bg-[#2d2d2d]">
+          <td class="px-4 py-2">{{ property.name }}</td>
+          <td class="px-4 py-2">{{ property.get_property_type_display }}</td>
+          <td class="px-4 py-2">{{ property.location }}</td>
+          <td class="px-4 py-2">
+            <a href="{% url 'admin_panel_edit_property' property.pk %}" class="text-blue-400 hover:underline mr-2">Edit</a>
+            <a href="{% url 'admin_panel_delete_property' property.pk %}" class="text-red-400 hover:underline mr-2">Delete</a>
+            <a href="{% url 'admin_panel_archive_property' property.pk %}" class="text-yellow-400 hover:underline">Archive</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="4" class="px-4 py-4 text-center text-gray-400">No properties found.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -7,7 +7,9 @@
 {% block content %}
 <div class="min-h-screen flex items-start justify-center pt-12 px-4 sm:px-6 lg:px-8">
   <div class="max-w-2xl w-full bg-gip border-2 border-gold p-8 rounded-xl shadow-xl">
-    <h2 class="text-center text-3xl font-extrabold text-gold mb-6">Add Property</h2>
+    <h2 class="text-center text-3xl font-extrabold text-gold mb-6">
+      {% if editing %}Edit Property{% else %}Add Property{% endif %}
+    </h2>
     {% if messages %}
       <ul class="mb-4">
         {% for message in messages %}
@@ -134,7 +136,9 @@
         {% endfor %}
       </div>
       <div>
-        <button type="submit" class="w-full flex justify-center py-2 px-4 button-gold text-[#232323] rounded-md shadow-md hover:shadow-lg focus:outline-none">Save</button>
+        <button type="submit" class="w-full flex justify-center py-2 px-4 button-gold text-[#232323] rounded-md shadow-md hover:shadow-lg focus:outline-none">
+          {% if editing %}Update{% else %}Save{% endif %}
+        </button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- add admin panel list page for properties
- make add/edit property template reusable
- add confirmation page for deletions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd5bda4fc8320b09465c810362d24