### PR TITLE
Add custom property management page

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
+    path('properties/', views.property_management, name='admin_panel_property_management'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -22,3 +22,17 @@ def dashboard(request):
     if request.user.is_superadmin or request.user.is_superuser:
         context['users_count'] = User.objects.count()
     return render(request, 'admin_panel/dashboard.html', context)
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def property_management(request):
+    """Custom property management page showing a list of properties."""
+    properties = Property.objects.all().order_by('-created_at')
+    return render(
+        request,
+        'admin_panel/property_management.html',
+        {
+            'properties': properties,
+        },
+    )

--- a/templates/admin_panel/dashboard.html
+++ b/templates/admin_panel/dashboard.html
@@ -26,7 +26,7 @@
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <!-- Properties card -->
-      <a href="{% url 'admin:properties_property_changelist' %}" class="transition-all hover:scale-105">
+      <a href="{% url 'admin_panel_property_management' %}" class="transition-all hover:scale-105">
         <div class="bg-blue-100 hover:bg-blue-200 rounded-lg p-6 shadow flex flex-col items-center">
           <svg class="w-10 h-10 mb-2 text-blue-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
             <path d="M4 10V6a2 2 0 0 1 2-2h3V2h6v2h3a2 2 0 0 1 2 2v4M4 10l8 8m0 0l8-8M12 18V9" stroke-linecap="round" stroke-linejoin="round"/>

--- a/templates/admin_panel/property_management.html
+++ b/templates/admin_panel/property_management.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+  <div class="bg-white/90 rounded-xl shadow-xl p-8 text-[#232323]">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold">Property Management</h1>
+      <a href="{% url 'admin:properties_property_add' %}" class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">Add Property</a>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          {% for property in properties %}
+          <tr>
+            <td class="px-6 py-4 whitespace-nowrap">{{ property.name }}</td>
+            <td class="px-6 py-4 whitespace-nowrap">{{ property.get_property_type_display }}</td>
+            <td class="px-6 py-4 whitespace-nowrap">{{ property.location }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-right">
+              <a href="{% url 'admin:properties_property_change' property.id %}" class="text-blue-600 hover:text-blue-900 mr-4">Edit</a>
+              <a href="{% url 'admin:properties_property_delete' property.id %}" class="text-red-600 hover:text-red-900">Delete</a>
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="4" class="px-6 py-4 text-center text-gray-500">No properties found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `property_management` view and URL
- link "Properties" card to new management page
- provide new `property_management.html` template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd8f4eb7c8320a9a69e4e83713d94