### PR TITLE
Add admin property management page

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -3,4 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
+    path('properties/', views.manage_properties, name='manage_properties'),
+    path('properties/<int:pk>/edit/', views.edit_property, name='edit_property'),
+    path('properties/<int:pk>/delete/', views.delete_property, name='delete_property'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -1,7 +1,9 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404, redirect
+from django.contrib import messages
 from accounts.models import User
 from properties.models import Property, Booking
+from properties.forms import PropertyForm
 
 def is_admin_or_superadmin(user):
     """Return True if the user has admin privileges."""
@@ -22,3 +24,47 @@ def dashboard(request):
     if request.user.is_superadmin or request.user.is_superuser:
         context['users_count'] = User.objects.count()
     return render(request, 'admin_panel/dashboard.html', context)
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def manage_properties(request):
+    """List properties with management actions."""
+    properties = Property.objects.all().order_by('-created_at')
+    return render(request, 'admin_panel/manage_properties.html', {'properties': properties})
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def edit_property(request, pk):
+    """Edit an existing property."""
+    property_obj = get_object_or_404(Property, pk=pk)
+    show_responsible = (
+        request.user.is_superuser
+        or getattr(request.user, 'is_superadmin', False)
+        or request.user.has_perm('properties.assign_responsible')
+    )
+    if request.method == 'POST':
+        form = PropertyForm(request.POST, request.FILES, instance=property_obj, user=request.user)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Property updated successfully.')
+            return redirect('admin_panel:manage_properties')
+    else:
+        form = PropertyForm(instance=property_obj, user=request.user)
+    return render(
+        request,
+        'admin_panel/edit_property.html',
+        {'form': form, 'show_responsible': show_responsible, 'property': property_obj}
+    )
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def delete_property(request, pk):
+    """Delete a property and redirect back to the list."""
+    property_obj = get_object_or_404(Property, pk=pk)
+    if request.method == 'POST':
+        property_obj.delete()
+        messages.success(request, 'Property deleted.')
+    return redirect('admin_panel:manage_properties')

--- a/templates/admin_panel/dashboard.html
+++ b/templates/admin_panel/dashboard.html
@@ -26,7 +26,7 @@
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <!-- Properties card -->
-      <a href="{% url 'admin:properties_property_changelist' %}" class="transition-all hover:scale-105">
+      <a href="{% url 'admin_panel:manage_properties' %}" class="transition-all hover:scale-105">
         <div class="bg-blue-100 hover:bg-blue-200 rounded-lg p-6 shadow flex flex-col items-center">
           <svg class="w-10 h-10 mb-2 text-blue-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
             <path d="M4 10V6a2 2 0 0 1 2-2h3V2h6v2h3a2 2 0 0 1 2 2v4M4 10l8 8m0 0l8-8M12 18V9" stroke-linecap="round" stroke-linejoin="round"/>

--- a/templates/admin_panel/edit_property.html
+++ b/templates/admin_panel/edit_property.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="min-h-screen flex items-start justify-center pt-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-2xl w-full bg-gip border-2 border-gold p-8 rounded-xl shadow-xl">
+    <h2 class="text-center text-3xl font-extrabold text-gold mb-6">Edit Property</h2>
+    <form method="post" enctype="multipart/form-data" class="space-y-4">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" class="w-full flex justify-center py-2 px-4 button-gold text-[#232323] rounded-md shadow-md hover:shadow-lg focus:outline-none">Save</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/admin_panel/manage_properties.html
+++ b/templates/admin_panel/manage_properties.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-3xl font-bold text-gold mb-6">Manage Properties</h1>
+{% if messages %}
+  <ul class="mb-4">
+  {% for message in messages %}
+    <li class="text-green-500">{{ message }}</li>
+  {% endfor %}
+  </ul>
+{% endif %}
+<div class="mb-4">
+  <a href="{% url 'add_property' %}" class="button-gold px-4 py-2 rounded">Add Property</a>
+</div>
+<div class="overflow-x-auto bg-white text-[#232323] rounded-lg shadow">
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Location</th>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-200">
+      {% for property in properties %}
+      <tr>
+        <td class="px-4 py-2 whitespace-nowrap">{{ property.name }}</td>
+        <td class="px-4 py-2 whitespace-nowrap">{{ property.get_property_type_display }}</td>
+        <td class="px-4 py-2 whitespace-nowrap">{{ property.location }}</td>
+        <td class="px-4 py-2 whitespace-nowrap">
+          <a href="{% url 'admin_panel:edit_property' property.pk %}" class="text-blue-600 hover:underline mr-3">Edit</a>
+          <form action="{% url 'admin_panel:delete_property' property.pk %}" method="post" class="inline">
+            {% csrf_token %}
+            <button type="submit" class="text-red-600 hover:underline" onclick="return confirm('Delete this property?');">Delete</button>
+          </form>
+        </td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="4" class="px-4 py-6 text-center text-gray-500">No properties found.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new admin panel property management views and URLs
- create templates for managing and editing properties
- update dashboard Properties link to use new page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fd8f4eb7c8320a9a69e4e83713d94