### PR TITLE
Enhance property management table

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,6 +42,19 @@ a:hover, .hover\:text-gold:hover {
   color: #232323;
 }
 
+.button-red {
+  background: #dc2626;
+  color: #fff;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-weight: 700;
+  transition: background 0.2s;
+}
+.button-red:hover {
+  background: #b91c1c;
+  color: #fff;
+}
+
 .navbar, .footer {
   background: var(--gip-bg) !important;
   color: var(--gip-text);

--- a/templates/admin_panel/manage_properties.html
+++ b/templates/admin_panel/manage_properties.html
@@ -11,6 +11,7 @@
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Photo</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
@@ -19,13 +20,20 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
           {% for property in properties %}
-          <tr>
+          <tr onclick="window.location.href='{% url 'admin:properties_property_change' property.id %}'" class="cursor-pointer hover:bg-gray-50">
+            <td class="px-6 py-4 whitespace-nowrap">
+              {% if property.photos.first %}
+                <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="h-16 w-20 object-cover rounded-lg" />
+              {% else %}
+                <div class="h-16 w-20 flex items-center justify-center bg-gray-100 text-gray-400 rounded-lg text-xs">No Photo</div>
+              {% endif %}
+            </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ property.name }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 flex gap-4">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 flex gap-4" onclick="event.stopPropagation();">
               <a href="{% url 'admin:properties_property_change' property.id %}" class="text-blue-600 hover:underline">Edit</a>
-              <a href="{% url 'admin:properties_property_delete' property.id %}" class="text-red-600 hover:underline">Delete</a>
+              <a href="{% url 'admin:properties_property_delete' property.id %}" class="button-red text-white px-3 py-1 rounded-md">Delete</a>
             </td>
           </tr>
           {% empty %}


### PR DESCRIPTION
## Summary
- make property rows clickable in admin panel
- show property photo preview
- add red delete button
- add reusable `.button-red` class

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fdcf81b90832082124789e0415407