### PR TITLE
Update admin property list design

### DIFF
--- a/templates/admin_panel/manage_properties.html
+++ b/templates/admin_panel/manage_properties.html
@@ -11,6 +11,7 @@
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Photo</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
@@ -19,13 +20,20 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
           {% for property in properties %}
-          <tr>
+          <tr class="cursor-pointer property-row" data-href="{% url 'admin:properties_property_change' property.id %}">
+            <td class="px-6 py-4 whitespace-nowrap">
+              {% if property.photos.first %}
+                <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-20 h-20 object-cover rounded-md border" />
+              {% else %}
+                <div class="w-20 h-20 flex items-center justify-center bg-gray-100 text-gray-400 rounded-md border">No Photo</div>
+              {% endif %}
+            </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ property.name }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 flex gap-4">
               <a href="{% url 'admin:properties_property_change' property.id %}" class="text-blue-600 hover:underline">Edit</a>
-              <a href="{% url 'admin:properties_property_delete' property.id %}" class="text-red-600 hover:underline">Delete</a>
+              <a href="{% url 'admin:properties_property_delete' property.id %}" class="delete-btn inline-block bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Delete</a>
             </td>
           </tr>
           {% empty %}
@@ -36,6 +44,17 @@
         </tbody>
       </table>
     </div>
-  </div>
 </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  document.querySelectorAll('.property-row').forEach(row => {
+    row.addEventListener('click', function(e) {
+      if (e.target.closest('.delete-btn')) return;
+      window.location = this.dataset.href;
+    });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show property photo and delete button in admin property list
- make table rows clickable to edit
- add client-side script for row navigation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fdcf81b90832082124789e0415407