### PR TITLE
Enable inline property deletion in admin panel

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
+    path('properties/<int:pk>/delete/', views.delete_property, name='admin_panel_delete_property'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
+from django.http import JsonResponse, HttpResponseNotAllowed
 from accounts.models import User
 from properties.models import Property, Booking
 
@@ -32,3 +33,15 @@ def manage_properties(request):
     return render(request, 'admin_panel/manage_properties.html', {
         'properties': properties,
     })
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def delete_property(request, pk):
+    """Delete a property via AJAX request."""
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+
+    prop = get_object_or_404(Property, pk=pk)
+    prop.delete()
+    return JsonResponse({"success": True})

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -351,9 +351,42 @@ document.addEventListener('DOMContentLoaded', () => {
     highlight();
   });
 
-  document.getElementById('detailClear')?.addEventListener('click', ()=>{
-    selStart = selEnd = null; highlight();
-  });
+document.getElementById('detailClear')?.addEventListener('click', ()=>{
+  selStart = selEnd = null; highlight();
+});
 
   render();
+});
+
+// -------------------------------------------------------------
+//  Admin-panel property deletion
+// -------------------------------------------------------------
+document.addEventListener('DOMContentLoaded', () => {
+  const getCookie = name => {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    return parts.length === 2 ? parts.pop().split(';').shift() : null;
+  };
+
+  document.querySelectorAll('.delete-property-btn').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      if(!confirm('Are you sure you want to delete this property?')) return;
+      const url = btn.dataset.url;
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': getCookie('csrftoken') || '',
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      }).then(resp => {
+        if(resp.ok){
+          btn.closest('tr')?.remove();
+        }else{
+          alert('Deletion failed');
+        }
+      }).catch(()=> alert('Deletion failed'));
+    });
+  });
 });

--- a/templates/admin_panel/manage_properties.html
+++ b/templates/admin_panel/manage_properties.html
@@ -32,7 +32,9 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-              <a href="{% url 'admin:properties_property_delete' property.id %}" class="inline-block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" onclick="event.stopPropagation();">Delete</a>
+              <a href="#" data-url="{% url 'admin_panel_delete_property' property.id %}"
+                 class="delete-property-btn inline-block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded"
+                 onclick="event.stopPropagation();">Delete</a>
             </td>
           </tr>
           {% empty %}


### PR DESCRIPTION
## Summary
- add AJAX view and URL for property deletion
- enhance admin panel template for inline delete
- support delete via fetch in `static/js/app.js`

## Testing
- `pytest -q` *(fails: no tests ran)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685fe317ab98832093b54b48681d7300