### PR TITLE
Enable AJAX property deletion in admin panel

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
+    path('properties/<int:pk>/delete/', views.delete_property, name='admin_panel_delete_property'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -32,3 +32,19 @@ def manage_properties(request):
     return render(request, 'admin_panel/manage_properties.html', {
         'properties': properties,
     })
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def delete_property(request, pk):
+    """Delete a property via AJAX from the management page."""
+    if request.method != "POST":
+        from django.http import HttpResponseNotAllowed
+        return HttpResponseNotAllowed(["POST"])
+
+    from django.shortcuts import get_object_or_404
+    from django.http import JsonResponse
+
+    prop = get_object_or_404(Property, pk=pk)
+    prop.delete()
+    return JsonResponse({"deleted": True})

--- a/templates/admin_panel/manage_properties.html
+++ b/templates/admin_panel/manage_properties.html
@@ -32,7 +32,7 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-              <a href="{% url 'admin:properties_property_delete' property.id %}" class="inline-block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" onclick="event.stopPropagation();">Delete</a>
+              <a href="#" data-url="{% url 'admin_panel_delete_property' property.id %}" class="delete-btn inline-block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" onclick="event.stopPropagation();">Delete</a>
             </td>
           </tr>
           {% empty %}
@@ -45,4 +45,30 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  function getCookie(name){
+    const v = document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');
+    return v ? v.pop() : '';
+  }
+  document.querySelectorAll('.delete-btn').forEach(btn => {
+    btn.addEventListener('click', function(e){
+      e.preventDefault();
+      e.stopPropagation();
+      if(!confirm('Delete this property?')) return;
+      fetch(this.dataset.url, {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getCookie('csrftoken'), 'X-Requested-With': 'XMLHttpRequest' }
+      }).then(resp => {
+        if(resp.ok){
+          this.closest('tr').remove();
+        } else {
+          alert('Error deleting property');
+        }
+      });
+    });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dedicated URL and view for property deletion
- update manage_properties page to delete via AJAX with confirmation dialog

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fe317ab98832093b54b48681d7300