### PR TITLE
Add AJAX deletion to admin panel properties

### DIFF
--- a/admin_panel/tests.py
+++ b/admin_panel/tests.py
@@ -1,3 +1,34 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from properties.models import Property
 
-# Create your tests here.
+class DeletePropertyTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_user(username='admin', password='pass', role='admin')
+        self.user = User.objects.create_user(username='user', password='pass')
+        self.prop = Property.objects.create(
+            name='Test',
+            property_type='short-term',
+            location='Loc',
+            description='Desc',
+            guests=1,
+            bedrooms=1,
+            bathrooms=1,
+            responsible=self.admin
+        )
+
+    def test_non_admin_cannot_delete(self):
+        self.client.login(username='user', password='pass')
+        url = reverse('admin_panel_delete_property', args=[self.prop.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Property.objects.filter(id=self.prop.id).exists())
+
+    def test_admin_can_delete(self):
+        self.client.login(username='admin', password='pass')
+        url = reverse('admin_panel_delete_property', args=[self.prop.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Property.objects.filter(id=self.prop.id).exists())

--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
+    path('properties/delete/<int:pk>/', views.delete_property, name='admin_panel_delete_property'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
 from accounts.models import User
 from properties.models import Property, Booking
 
@@ -32,3 +34,13 @@ def manage_properties(request):
     return render(request, 'admin_panel/manage_properties.html', {
         'properties': properties,
     })
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+@require_POST
+def delete_property(request, pk):
+    """Delete a property and return JSON response."""
+    prop = get_object_or_404(Property, pk=pk)
+    prop.delete()
+    return JsonResponse({'success': True})

--- a/templates/admin_panel/manage_properties.html
+++ b/templates/admin_panel/manage_properties.html
@@ -20,7 +20,7 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
           {% for property in properties %}
-          <tr onclick="window.location='{% url 'admin:properties_property_change' property.id %}'" class="hover:bg-gray-50 cursor-pointer">
+          <tr data-id="{{ property.id }}" onclick="window.location='{% url 'admin:properties_property_change' property.id %}'" class="hover:bg-gray-50 cursor-pointer">
             <td class="px-6 py-4 whitespace-nowrap">
               {% if property.photos.first %}
                 <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-16 h-16 object-cover rounded">
@@ -32,7 +32,7 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-              <a href="{% url 'admin:properties_property_delete' property.id %}" class="inline-block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" onclick="event.stopPropagation();">Delete</a>
+              <a href="#" data-url="{% url 'admin_panel_delete_property' property.id %}" class="delete-property inline-block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" onclick="event.stopPropagation();">Delete</a>
             </td>
           </tr>
           {% empty %}
@@ -45,4 +45,44 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  function getCookie(name) {
+    let value = null;
+    if (document.cookie && document.cookie !== '') {
+      const cookies = document.cookie.split(';');
+      for (let c of cookies) {
+        c = c.trim();
+        if (c.substring(0, name.length + 1) === (name + '=')) {
+          value = decodeURIComponent(c.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return value;
+  }
+  const csrf = getCookie('csrftoken');
+  document.querySelectorAll('.delete-property').forEach(btn => {
+    btn.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!confirm('Delete this property?')) return;
+      const row = btn.closest('tr');
+      fetch(btn.dataset.url, {
+        method: 'POST',
+        headers: { 'X-CSRFToken': csrf }
+      }).then(resp => {
+        if (resp.ok) {
+          row.remove();
+        } else {
+          alert('Failed to delete property.');
+        }
+      }).catch(() => alert('Failed to delete property.'));
+    });
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow deleting properties from custom admin panel without redirection
- wire view for property deletion and route
- add inline JS to handle confirmation & AJAX request
- test property deletion rules

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fe317ab98832093b54b48681d7300