### PR TITLE
Add custom bookings management page

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
     path('properties/<int:pk>/delete/', views.delete_property, name='admin_panel_delete_property'),
+    path('bookings/', views.manage_bookings, name='admin_panel_manage_bookings'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -48,3 +48,13 @@ def delete_property(request, pk):
     prop = get_object_or_404(Property, pk=pk)
     prop.delete()
     return JsonResponse({"deleted": True})
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def manage_bookings(request):
+    """Custom bookings management page listing all bookings."""
+    bookings = Booking.objects.select_related("property", "user").order_by("-created_at")
+    return render(request, "admin_panel/manage_bookings.html", {
+        "bookings": bookings,
+    })

--- a/templates/admin_panel/dashboard.html
+++ b/templates/admin_panel/dashboard.html
@@ -36,7 +36,7 @@
         </div>
       </a>
       <!-- Bookings card -->
-      <a href="{% url 'admin:properties_booking_changelist' %}" class="transition-all hover:scale-105">
+      <a href="{% url 'admin_panel_manage_bookings' %}" class="transition-all hover:scale-105">
         <div class="bg-green-100 hover:bg-green-200 rounded-lg p-6 shadow flex flex-col items-center">
           <svg class="w-10 h-10 mb-2 text-green-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
             <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2"/>

--- a/templates/admin_panel/manage_bookings.html
+++ b/templates/admin_panel/manage_bookings.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+  <div class="bg-white/90 rounded-xl shadow-xl p-8">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6">Manage Bookings</h1>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Property</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Check-in</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Check-out</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          {% for booking in bookings %}
+          <tr class="hover:bg-gray-50">
+            <td class="px-6 py-4 whitespace-nowrap">{{ booking.property.name }}</td>
+            <td class="px-6 py-4 whitespace-nowrap">
+              {% if booking.user %}{{ booking.user.get_full_name|default:booking.user.username }}{% else %}-{% endif %}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap">{{ booking.start_date }}</td>
+            <td class="px-6 py-4 whitespace-nowrap">{{ booking.end_date }}</td>
+            <td class="px-6 py-4 whitespace-nowrap">{{ booking.get_status_display }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <a href="{% url 'admin:properties_booking_change' booking.id %}" class="text-blue-600 hover:underline">View</a>
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">No bookings found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new admin panel route to manage bookings
- implement `manage_bookings` view
- create `manage_bookings.html` template
- link bookings card on dashboard to new page

## Testing
- `python3 -m pytest -q`
- `flake8` *(fails: command not found)*
- `python3 manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fe5851f6c8320ad1495da6d03c134