### PR TITLE
Add admin bookings overview

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
     path('properties/<int:pk>/delete/', views.delete_property, name='admin_panel_delete_property'),
+    path('bookings/', views.manage_bookings, name='admin_panel_manage_bookings'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -48,3 +48,13 @@ def delete_property(request, pk):
     prop = get_object_or_404(Property, pk=pk)
     prop.delete()
     return JsonResponse({"deleted": True})
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def manage_bookings(request):
+    """Display a list of bookings for admins."""
+    bookings = Booking.objects.select_related('property', 'user').order_by('-created_at')
+    return render(request, 'admin_panel/manage_bookings.html', {
+        'bookings': bookings,
+    })

--- a/templates/admin_panel/dashboard.html
+++ b/templates/admin_panel/dashboard.html
@@ -36,7 +36,7 @@
         </div>
       </a>
       <!-- Bookings card -->
-      <a href="{% url 'admin:properties_booking_changelist' %}" class="transition-all hover:scale-105">
+      <a href="{% url 'admin_panel_manage_bookings' %}" class="transition-all hover:scale-105">
         <div class="bg-green-100 hover:bg-green-200 rounded-lg p-6 shadow flex flex-col items-center">
           <svg class="w-10 h-10 mb-2 text-green-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
             <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2"/>

--- a/templates/admin_panel/manage_bookings.html
+++ b/templates/admin_panel/manage_bookings.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+  <div class="bg-white/90 rounded-xl shadow-xl p-8">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6">Manage Bookings</h1>
+    <div class="mb-4">
+      <a href="{% url 'admin:properties_booking_add' %}" class="button-gold inline-block">Add New Booking</a>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Property</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Dates</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          {% for booking in bookings %}
+          <tr class="hover:bg-gray-50">
+            <td class="px-6 py-4 whitespace-nowrap">{{ booking.property.name }}</td>
+            <td class="px-6 py-4 whitespace-nowrap">{{ booking.user.get_full_name|default:booking.user.username }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ booking.start_date }} - {{ booking.end_date }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ booking.get_status_display }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <a href="{% url 'admin:properties_booking_change' booking.id %}" class="text-blue-600 hover:text-blue-800 hover:underline">View / Edit</a>
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">No bookings found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `manage_bookings` view for admins
- hook the view in admin panel urls
- link bookings dashboard card to new page
- provide a Tailwind template for viewing bookings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685feb2a2c848320beb284b3cc0320cc