### PR TITLE
Implement admin bookings list

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
+    path('bookings/', views.manage_bookings, name='admin_panel_bookings'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
     path('properties/<int:pk>/delete/', views.delete_property, name='admin_panel_delete_property'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -26,6 +26,21 @@ def dashboard(request):
 
 @login_required
 @user_passes_test(is_admin_or_superadmin)
+def manage_bookings(request):
+    """List properties for bookings, optionally filtered by type."""
+    property_type = request.GET.get('type', 'short-term')
+    qs = Property.objects.all()
+    if property_type in ['short-term', 'long-term', 'investment']:
+        qs = qs.filter(property_type=property_type)
+    properties = qs.order_by('name')
+    return render(request, 'admin_panel/manage_bookings.html', {
+        'properties': properties,
+        'property_type': property_type,
+    })
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
 def manage_properties(request):
     """Custom property management page listing all properties."""
     properties = Property.objects.all().order_by('-created_at')

--- a/templates/admin_panel/dashboard.html
+++ b/templates/admin_panel/dashboard.html
@@ -36,7 +36,7 @@
         </div>
       </a>
       <!-- Bookings card -->
-      <a href="{% url 'admin:properties_booking_changelist' %}" class="transition-all hover:scale-105">
+      <a href="{% url 'admin_panel_bookings' %}" class="transition-all hover:scale-105">
         <div class="bg-green-100 hover:bg-green-200 rounded-lg p-6 shadow flex flex-col items-center">
           <svg class="w-10 h-10 mb-2 text-green-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
             <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2"/>

--- a/templates/admin_panel/manage_bookings.html
+++ b/templates/admin_panel/manage_bookings.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+  <div class="bg-white/90 rounded-xl shadow-xl p-8">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6">Bookings</h1>
+    <form method="get" class="mb-6">
+      <label for="type" class="mr-2 font-semibold text-gray-700">Property Type:</label>
+      <select name="type" id="type" onchange="this.form.submit()" class="border rounded px-3 py-2">
+        <option value="">All</option>
+        <option value="short-term" {% if property_type == 'short-term' %}selected{% endif %}>Short-Term</option>
+        <option value="long-term" {% if property_type == 'long-term' %}selected{% endif %}>Long-Term</option>
+        <option value="investment" {% if property_type == 'investment' %}selected{% endif %}>Investment</option>
+      </select>
+    </form>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          {% for property in properties %}
+          <tr class="hover:bg-gray-50">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ property.name }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="3" class="px-6 py-4 text-center text-sm text-gray-500">No properties found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add bookings URL to admin_panel
- implement a simple bookings management view
- link the dashboard Bookings card to the new page
- create a bookings listing page with filtering by property type

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fed5030588320834f09a136fe3725