### PR TITLE
Add calendar-based booking management

### DIFF
--- a/admin_panel/urls.py
+++ b/admin_panel/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path('', views.dashboard, name='admin_panel_dashboard'),
     path('bookings/', views.manage_bookings, name='admin_panel_bookings'),
+    path('bookings/<int:pk>/', views.property_bookings, name='admin_panel_property_bookings'),
     path('properties/', views.manage_properties, name='admin_panel_manage_properties'),
     path('properties/<int:pk>/delete/', views.delete_property, name='admin_panel_delete_property'),
 ]

--- a/admin_panel/views.py
+++ b/admin_panel/views.py
@@ -64,3 +64,75 @@ def manage_bookings(request):
         "admin_panel/manage_bookings.html",
         {"properties": properties, "filter_type": filter_type},
     )
+
+
+@login_required
+@user_passes_test(is_admin_or_superadmin)
+def property_bookings(request, pk):
+    """Display and manage bookings for a specific property."""
+    from django.shortcuts import get_object_or_404, redirect
+    from datetime import datetime, timedelta
+    import json
+    from django.core.serializers.json import DjangoJSONEncoder
+
+    prop = get_object_or_404(Property, pk=pk)
+
+    # Existing booked ranges
+    bookings = Booking.objects.filter(property=prop, status="booked")
+    booked = [
+        {
+            "start": b.start_date.isoformat(),
+            "end": (b.end_date + timedelta(days=1)).isoformat(),
+        }
+        for b in bookings
+    ]
+
+    error = None
+    success = None
+
+    if request.method == "POST":
+        start_str = request.POST.get("start_date")
+        end_str = request.POST.get("end_date")
+        try:
+            start_date = datetime.fromisoformat(start_str).date() if start_str else None
+            end_date = datetime.fromisoformat(end_str).date() if end_str else None
+        except Exception:
+            start_date = end_date = None
+
+        if not start_date or not end_date or start_date >= end_date:
+            error = "Please select a valid range."
+        else:
+            overlap = Booking.objects.filter(
+                property=prop,
+                status="booked",
+                start_date__lt=end_date,
+                end_date__gt=start_date,
+            ).exists()
+            if overlap:
+                error = "Those dates are already booked."
+            else:
+                Booking.objects.create(
+                    property=prop,
+                    user=request.user,
+                    start_date=start_date,
+                    end_date=end_date,
+                    status="booked",
+                )
+                success = "Dates blocked successfully."
+                # Refresh booked ranges to include the new booking
+                bookings = Booking.objects.filter(property=prop, status="booked")
+                booked = [
+                    {
+                        "start": b.start_date.isoformat(),
+                        "end": (b.end_date + timedelta(days=1)).isoformat(),
+                    }
+                    for b in bookings
+                ]
+
+    context = {
+        "property": prop,
+        "booked_dates_json": json.dumps(booked, cls=DjangoJSONEncoder),
+        "error": error,
+        "success": success,
+    }
+    return render(request, "admin_panel/property_calendar.html", context)

--- a/templates/admin_panel/manage_bookings.html
+++ b/templates/admin_panel/manage_bookings.html
@@ -30,7 +30,7 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.get_property_type_display }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ property.location }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm">
-              <a href="{% url 'admin:properties_booking_changelist' %}?property__id__exact={{ property.id }}" class="text-blue-600 hover:text-blue-800 hover:underline">View Bookings</a>
+              <a href="{% url 'admin_panel_property_bookings' property.id %}" class="text-blue-600 hover:text-blue-800 hover:underline">Manage Calendar</a>
             </td>
           </tr>
           {% empty %}

--- a/templates/admin_panel/property_calendar.html
+++ b/templates/admin_panel/property_calendar.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="max-w-5xl mx-auto mt-10 p-6 md:p-12 bg-white rounded-2xl shadow-2xl flex flex-col gap-6 text-[#232323]">
+  <h1 class="text-3xl font-bold text-gold">{{ property.name }} - Manage Bookings</h1>
+
+  <script id="bookedDatesJSON" type="application/json">
+    {{ booked_dates_json|safe }}
+  </script>
+
+  <div id="detailCalendarContainer" class="overflow-x-auto text-base w-full">
+    <div id="detailCalendarGrid" class="flex gap-6 select-none"></div>
+  </div>
+  <div class="flex items-center gap-4">
+    <span id="detailSelected" class="text-gray-700 text-sm"></span>
+    <button id="detailClear" type="button" class="text-xs underline text-gray-500 hover:text-gold">Clear</button>
+  </div>
+
+  <form method="post" class="flex flex-col sm:flex-row gap-4 items-end">
+    {% csrf_token %}
+    <div>
+      <label for="start_date" class="block text-sm font-medium text-gray-700">Start</label>
+      <input type="text" name="start_date" id="start_date" readonly class="border border-gray-300 rounded p-2">
+    </div>
+    <div>
+      <label for="end_date" class="block text-sm font-medium text-gray-700">End</label>
+      <input type="text" name="end_date" id="end_date" readonly class="border border-gray-300 rounded p-2">
+    </div>
+    <button type="submit" class="bg-gold text-[#232323] font-bold px-6 py-2 rounded shadow hover:scale-105">Block Dates</button>
+    {% if error %}<span class="text-red-500 text-sm">{{ error }}</span>{% endif %}
+    {% if success %}<span class="text-green-600 text-sm">{{ success }}</span>{% endif %}
+  </form>
+</div>
+<script>
+// Sync inputs with selected dates
+document.addEventListener('DOMContentLoaded', function(){
+  const grid = document.getElementById('detailCalendarGrid');
+  const s = document.getElementById('start_date');
+  const e = document.getElementById('end_date');
+  if(!grid || !s || !e) return;
+  grid.addEventListener('click', function(){
+    const st = grid.querySelector('button.range-start');
+    const en = grid.querySelector('button.range-end');
+    s.value = st ? st.dataset.date : '';
+    e.value = en ? en.dataset.date : '';
+  });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- link from admin bookings page to a new booking calendar page
- implement `property_bookings` view for admins to reserve dates
- add template for calendar-based booking management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600e6886cc83209ddf5d7759ef3f0a