### PR TITLE
Fix map highlight lock

### DIFF
--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -144,7 +144,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script>
-  const map = L.map('map').setView([36.7213, -4.4217], 12);
+  const map = L.map('map', { keyboard: false, scrollWheelZoom: false }).setView([36.7213, -4.4217], 12);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; OpenStreetMap contributors'
   }).addTo(map);


### PR DESCRIPTION
## Summary
- keep Leaflet map from hijacking keyboard and scroll on the add property page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860118f5268832099f21adb3a47a417