### PR TITLE
Fix map overlay on add property page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -236,4 +236,6 @@ a:hover, .hover\:text-gold:hover {
 /* ----- Photo gallery ----- */
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
-#photoModal{ display:flex; }
+#photoModal:not(.hidden){
+  display:flex;
+}


### PR DESCRIPTION
## Summary
- fix overlay by only displaying photo modal when not hidden

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860118f5268832099f21adb3a47a417