### PR TITLE
Fix map overlay blocking inputs

### DIFF
--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -39,7 +39,7 @@
           <p class="text-red-500 text-sm">{{ error }}</p>
         {% endfor %}
       </div>
-      <div id="map" class="w-full h-64 rounded-md border border-gold mb-4"></div>
+      <div id="map" class="relative w-full h-64 rounded-md border border-gold mb-4"></div>
       <div>
         <label for="id_location" class="block text-sm font-medium text-gold">Location</label>
         {{ form.location }}


### PR DESCRIPTION
## Summary
- ensure map container is positioned relative so it doesn't overlay other form fields

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860118f5268832099f21adb3a47a417