### PR TITLE
Fix property modal overlay issue

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -6,6 +6,8 @@ function setActiveField(el){
 
 // Mobile Navbar Toggle (if not handled inline)
 document.addEventListener('DOMContentLoaded', function () {
+  // Safety: ensure the quick-view modal is hidden on load
+  document.getElementById('propertyModal')?.classList.add('hidden');
   const btn = document.getElementById('mobile-menu-button');
   const menu = document.getElementById('mobile-menu');
   const openIcon = document.getElementById('mobile-menu-icon-open');


### PR DESCRIPTION
## Summary
- ensure the quick‑view modal is forced hidden when the DOM loads

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68601fc0948883209f6539ce6f916690