### PR TITLE
Fix persistent modal overlay

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -357,3 +357,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   render();
 });
+
+// Safety-net: ensure quick-view modal is hidden when new pages load
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('propertyModal')?.classList.add('hidden');
+});


### PR DESCRIPTION
## Summary
- ensure quick-view modal starts hidden on each page load

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68601fc0948883209f6539ce6f916690