### PR TITLE
Fix photo modal overlay

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -236,4 +236,4 @@ a:hover, .hover\:text-gold:hover {
 /* ----- Photo gallery ----- */
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
-#photoModal{ display:flex; }
+#photoModal{ display:none; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -6,6 +6,8 @@ function setActiveField(el){
 
 // Mobile Navbar Toggle (if not handled inline)
 document.addEventListener('DOMContentLoaded', function () {
+  // Ensure photo modal hidden on load if present
+  document.getElementById('photoModal')?.classList.add('hidden');
   const btn = document.getElementById('mobile-menu-button');
   const menu = document.getElementById('mobile-menu');
   const openIcon = document.getElementById('mobile-menu-icon-open');

--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -206,6 +206,9 @@
   updateFacilities();
 
   /* ---------- Photos upload & gallery ---------- */
+  document.addEventListener('DOMContentLoaded',()=>{
+    document.getElementById('photoModal')?.classList.add('hidden');
+  });
   const photoInput   = document.getElementById('id_photos');
   const addPhotosBtn = document.getElementById('addPhotosBtn');
   const gallery      = document.getElementById('photoGallery');
@@ -252,17 +255,13 @@
   }
 
   new Sortable(gallery, { animation: 150, onEnd: updateOrder });
-
-  closeModal?.addEventListener('click', () => {
+  const closePhoto = () => {
     modal.classList.add('hidden');
     modalImg.src = '';
-  });
-  modal?.addEventListener('click', e => {
-    if(e.target === modal){
-      modal.classList.add('hidden');
-      modalImg.src = '';
-    }
-  });
+  };
+  closeModal?.addEventListener('click', closePhoto);
+  modal?.addEventListener('click', e => { if(e.target === modal) closePhoto(); });
+  window.addEventListener('keydown', e => { if(e.key === 'Escape') closePhoto(); });
 
   document.querySelector('form')?.addEventListener('submit', () => {
     const dt = new DataTransfer();


### PR DESCRIPTION
## Summary
- hide photo modal by default in CSS
- ensure hidden state on DOMContentLoaded
- improve close handlers for photo modal

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860223765f08320b7d7716a634a9ccb