### PR TITLE
Fix photo modal default visibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -236,4 +236,4 @@ a:hover, .hover\:text-gold:hover {
 /* ----- Photo gallery ----- */
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
-#photoModal{ display:flex; }
+#photoModal{ display:none; }

--- a/templates/properties/add_property.html
+++ b/templates/properties/add_property.html
@@ -212,6 +212,10 @@
   const modal        = document.getElementById('photoModal');
   const modalImg     = document.getElementById('photoModalImg');
   const closeModal   = document.getElementById('closePhotoModal');
+  // ensure modal hidden on initial load
+  document.addEventListener('DOMContentLoaded',()=>{
+    modal?.classList.add('hidden');
+  });
   let photoFiles = [];
 
   if(photoInput) photoInput.classList.add('hidden');
@@ -252,16 +256,18 @@
   }
 
   new Sortable(gallery, { animation: 150, onEnd: updateOrder });
-
-  closeModal?.addEventListener('click', () => {
+  const closePhoto = () => {
     modal.classList.add('hidden');
     modalImg.src = '';
-  });
+  };
+  closeModal?.addEventListener('click', closePhoto);
   modal?.addEventListener('click', e => {
     if(e.target === modal){
-      modal.classList.add('hidden');
-      modalImg.src = '';
+      closePhoto();
     }
+  });
+  window.addEventListener('keydown', e => {
+    if(e.key === 'Escape') closePhoto();
   });
 
   document.querySelector('form')?.addEventListener('submit', () => {


### PR DESCRIPTION
## Summary
- ensure the photo modal is hidden by default in the CSS
- hide photo modal on load and tighten close behaviour

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6860223765f08320b7d7716a634a9ccb