### PR TITLE
fix photo modal overlay

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -236,4 +236,4 @@ a:hover, .hover\:text-gold:hover {
 /* ----- Photo gallery ----- */
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
-#photoModal{ display:flex; }
+#photoModal{ display:none; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -117,6 +117,21 @@ document.addEventListener('DOMContentLoaded', function () {
       setActiveField(null);
     }
   });
+
+  /* -------------- Photo modal -------------- */
+  const modal        = document.getElementById('photoModal');
+  const modalImg     = document.getElementById('photoModalImg');
+  const closePhotoModal = document.getElementById('closePhotoModal');
+  if (modal) {
+    modal.classList.add('hidden');
+    const closePhoto = () => {
+      modal.classList.add('hidden');
+      if (modalImg) modalImg.src = '';
+    };
+    closePhotoModal?.addEventListener('click', closePhoto);
+    modal.addEventListener('click', e => { if (e.target === modal) closePhoto(); });
+    window.addEventListener('keydown', e => { if (e.key === 'Escape') closePhoto(); });
+  }
 });
 
 // Future: Image carousel, drag-drop, modals, map integration JS goes here.


### PR DESCRIPTION
## Summary
- hide `#photoModal` with CSS by default
- init and close photo modal reliably via JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860223765f08320b7d7716a634a9ccb