### PR TITLE
Fix photo modal default visibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -236,4 +236,4 @@ a:hover, .hover\:text-gold:hover {
 /* ----- Photo gallery ----- */
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
-#photoModal{ display:flex; }
+#photoModal{ display:none; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -28,6 +28,25 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
+  // Ensure photo modal is hidden on load
+  document.getElementById('photoModal')?.classList.add('hidden');
+
+  // Photo modal close handlers
+  const photoModal     = document.getElementById('photoModal');
+  const photoModalImg  = document.getElementById('photoModalImg');
+  const closePhotoModal = document.getElementById('closePhotoModal');
+  const closePhoto = () => {
+    photoModal?.classList.add('hidden');
+    if(photoModalImg) photoModalImg.src = '';
+  };
+  closePhotoModal?.addEventListener('click', closePhoto);
+  photoModal?.addEventListener('click', e => {
+    if(e.target === photoModal) closePhoto();
+  });
+  window.addEventListener('keydown', e => {
+    if(e.key === 'Escape') closePhoto();
+  });
+
   /* ------- Search bar glass focus ------- */
   whereField    = document.getElementById('whereField');
   checkinField  = document.getElementById('checkinField');


### PR DESCRIPTION
## Summary
- hide `#photoModal` with CSS
- ensure the photo modal is hidden when DOM is ready
- add more robust modal close handlers

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6860223765f08320b7d7716a634a9ccb