### PR TITLE
Fix overlay modal blocking form

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -236,4 +236,4 @@ a:hover, .hover\:text-gold:hover {
 /* ----- Photo gallery ----- */
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
-#photoModal{ display:flex; }
+#photoModal:not(.hidden){ display:flex; }


### PR DESCRIPTION
## Summary
- correct the CSS rule for the photo modal so the overlay is hidden until triggered

## Testing
- `python -m pytest -q`
- `pytest`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6860269fd8508320908ad4ab0c254c0a