### PR TITLE
Fix search bar filtering with booked dates

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -35,6 +35,20 @@ document.addEventListener('DOMContentLoaded', function () {
   whoField      = document.getElementById('whoField');
   searchFields  = [whereField, checkinField, checkoutField, whoField];
 
+  if(startDateInput && startDateInput.value){
+    startDate = startDateInput.value;
+    checkInInput.value = new Date(startDate).toLocaleDateString();
+    calDropdown.dataset.start = startDate;
+  }
+  if(endDateInput && endDateInput.value){
+    endDate = endDateInput.value;
+    checkOutInput.value = new Date(endDate).toLocaleDateString();
+    calDropdown.dataset.end = endDate;
+  }
+  if(startDate || endDate){
+    highlightSelection();
+  }
+
   const whereInput = document.querySelector('input[name="q"]');
   whereInput?.addEventListener('focus', ()=> setActiveField(whereField));
   whereInput?.addEventListener('blur',  ()=> setActiveField(null));
@@ -131,6 +145,8 @@ const calPrev        = document.getElementById('calPrev');
 const calNext        = document.getElementById('calNext');
 const calApply       = document.getElementById('calApply');
 const calClear       = document.getElementById('calClear');
+const startDateInput = document.getElementById('startDateInput');
+const endDateInput   = document.getElementById('endDateInput');
 
 let currentMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1); // first of this month
 let startDate = null;
@@ -217,6 +233,8 @@ function highlightSelection(){
   checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
+  if(startDateInput) startDateInput.value = startDate || '';
+  if(endDateInput) endDateInput.value = endDate || '';
 
   if(start && !end){
     calendarField = 'checkout';

--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -25,6 +25,7 @@
         <span class="text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
+               value="{{ request.GET.checkin|default_if_none:'' }}"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar('checkin')"
@@ -37,6 +38,7 @@
         <span class="text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
+               value="{{ request.GET.checkout|default_if_none:'' }}"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar('checkout')"
@@ -137,6 +139,10 @@
           </div>
         </div>
       </div>
+
+      <!-- Hidden ISO date fields -->
+      <input type="hidden" name="start_date" id="startDateInput" value="{{ request.GET.start_date|default_if_none:'' }}" />
+      <input type="hidden" name="end_date" id="endDateInput" value="{{ request.GET.end_date|default_if_none:'' }}" />
 
       <!-- Search button -->
       <button type="submit"


### PR DESCRIPTION
## Summary
- enable searching by location, guest count and availability
- preserve selected dates across requests
- store ISO dates in hidden fields and sync with calendar UI

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860bb0178b883208ac4f94645254cd4