### PR TITLE
Improve mobile layout on property list page

### DIFF
--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -6,7 +6,7 @@
   {% if filter_type == 'short-term' %}
   <div class="flex justify-center mb-10">
     <form method="get"
-          class="flex items-center w-full max-w-7xl rounded-full bg-white border border-gray-200 shadow-lg px-4 py-3
+          class="flex flex-col sm:flex-row items-stretch sm:items-center w-full max-w-7xl rounded-full bg-white border border-gray-200 shadow-lg px-4 py-3 gap-3 sm:gap-0
                  md:px-8 md:py-4 relative">
       <!-- Where -->
       <div id="whereField" class="search-field flex-1 flex flex-col justify-center">
@@ -45,7 +45,7 @@
 
       <!-- Calendar dropdown -->
       <div id="calendarDropdown"
-           class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[1050px] rounded-3xl shadow-2xl bg-white z-50 p-10 hidden border border-gray-100"
+           class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[95vw] sm:w-[1050px] rounded-3xl shadow-2xl bg-white z-50 p-10 hidden border border-gray-100"
            data-start=""
            data-end="">
         <div id="calendarHeader" class="flex items-center justify-between mb-4">
@@ -80,7 +80,7 @@
 
         <!-- Dropdown -->
         <div id="whoDropdown"
-             class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[500px] rounded-3xl shadow-2xl bg-white z-50 p-6 hidden border border-gray-100">
+             class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[90vw] sm:w-[500px] rounded-3xl shadow-2xl bg-white z-50 p-6 hidden border border-gray-100">
           <!-- Adults -->
           <div class="flex justify-between items-center py-4">
             <div>
@@ -140,7 +140,7 @@
 
       <!-- Search button -->
       <button type="submit"
-              class="ml-3 md:ml-6 flex items-center justify-center w-14 h-14 rounded-full bg-gold text-white shadow transition hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-gold/30 absolute right-4 md:static md:relative">
+              class="ml-0 sm:ml-3 md:ml-6 mt-3 sm:mt-0 flex items-center justify-center w-full sm:w-14 h-12 sm:h-14 rounded-full bg-gold text-white shadow transition hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-gold/30 sm:absolute sm:right-4 md:static md:relative">
         <svg class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <circle cx="11" cy="11" r="8" stroke="currentColor" />
           <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" />
@@ -167,7 +167,7 @@
   </div>
 
   <!-- Grid of Property Cards -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8">
+  <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
     {% for property in properties %}
       <div
         class="property-card card-3d bg-white rounded-2xl shadow-xl flex flex-col overflow-hidden border border-gold cursor-pointer"
@@ -178,9 +178,9 @@
         data-url="{% url 'properties:property_detail' property.pk %}"
       >
         {% if property.photos.all %}
-          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-48 object-cover">
+          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-40 sm:h-48 object-cover">
         {% else %}
-          <div class="w-full h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-3xl">
+          <div class="w-full h-40 sm:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-3xl">
             No Photo
           </div>
         {% endif %}
@@ -208,9 +208,9 @@
             {% endif %}
           </div>
           <div class="text-gray-700 text-sm mb-4 line-clamp-2">{{ property.description }}</div>
-          <div class="flex gap-3 mt-auto">
-            <a href="{% url 'properties:property_detail' property.pk %}" class="button-gold w-full text-center flex items-center justify-center font-bold text-lg py-3 transition rounded-lg shadow hover:scale-105">More Info</a>
-            <a href="{% url 'properties:property_detail' property.pk %}#reserve" class="button-gold w-full text-center flex items-center justify-center font-bold text-lg py-3 transition rounded-lg shadow hover:scale-105">Reserve</a>
+          <div class="flex gap-2 mt-auto">
+            <a href="{% url 'properties:property_detail' property.pk %}" class="button-gold w-full text-center flex items-center justify-center font-bold text-base sm:text-lg py-2 sm:py-3 transition rounded-lg shadow hover:scale-105">More Info</a>
+            <a href="{% url 'properties:property_detail' property.pk %}#reserve" class="button-gold w-full text-center flex items-center justify-center font-bold text-base sm:text-lg py-2 sm:py-3 transition rounded-lg shadow hover:scale-105">Reserve</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make search form stack on small screens
- prevent dropdown overflow on mobile
- shrink property card grid and images for phones
- tweak buttons for smaller viewport

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686506f06dd883209dbef034d9825d1b