### PR TITLE
Improve mobile layout for properties page

### DIFF
--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -6,46 +6,45 @@
   {% if filter_type == 'short-term' %}
   <div class="flex justify-center mb-10">
     <form method="get"
-          class="flex items-center w-full max-w-7xl rounded-full bg-white border border-gray-200 shadow-lg px-4 py-3
-                 md:px-8 md:py-4 relative">
+          class="flex flex-wrap items-center w-full max-w-7xl rounded-2xl md:rounded-full bg-white border border-gray-200 shadow-lg p-4 md:px-8 md:py-4 gap-3">
       <!-- Where -->
-      <div id="whereField" class="search-field flex-1 flex flex-col justify-center">
-        <span class="text-base font-bold text-[#232323]">Where</span>
+      <div id="whereField" class="search-field flex-1 min-w-[150px] flex flex-col justify-center">
+        <span class="text-sm sm:text-base font-bold text-[#232323]">Where</span>
         <input type="text"
                name="q"
                value="{{ request.GET.q|default_if_none:'' }}"
                placeholder="Search destinations"
-               class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400" />
+               class="w-full text-base sm:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400" />
       </div>
       <!-- Divider -->
       <div class="mx-2 h-10 w-px bg-gray-200 hidden md:block"></div>
 
       <!-- Check in -->
-      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center">
-        <span class="text-base font-bold text-[#232323]">Check in</span>
+      <div id="checkinField" class="search-field flex-1 min-w-[150px] flex flex-col justify-center">
+        <span class="text-sm sm:text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar('checkin')"
-               class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
+               class="w-full text-base sm:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
       </div>
       <div class="mx-2 h-10 w-px bg-gray-200 hidden md:block"></div>
 
       <!-- Check out -->
-      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center">
-        <span class="text-base font-bold text-[#232323]">Check out</span>
+      <div id="checkoutField" class="search-field flex-1 min-w-[150px] flex flex-col justify-center">
+        <span class="text-sm sm:text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar('checkout')"
-               class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
+               class="w-full text-base sm:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
       </div>
 
       <!-- Calendar dropdown -->
       <div id="calendarDropdown"
-           class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[1050px] rounded-3xl shadow-2xl bg-white z-50 p-10 hidden border border-gray-100"
+           class="absolute top-full left-0 sm:left-1/2 sm:-translate-x-1/2 mt-4 w-full max-w-sm sm:max-w-[1050px] rounded-3xl shadow-2xl bg-white z-50 p-6 sm:p-10 hidden border border-gray-100"
            data-start=""
            data-end="">
         <div id="calendarHeader" class="flex items-center justify-between mb-4">
@@ -65,8 +64,8 @@
       <div class="mx-2 h-10 w-px bg-gray-200 hidden md:block"></div>
 
       <!-- Who -->
-      <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-center">
-        <span class="text-base font-bold text-[#232323]">Who</span>
+      <div id="whoField" class="search-field relative flex-1 min-w-[150px] flex flex-col justify-center items-center">
+        <span class="text-sm sm:text-base font-bold text-[#232323]">Who</span>
         <input
           id="whoInput"
           type="text"
@@ -74,13 +73,13 @@
           readonly
           value="Add guests"
           placeholder="Add guests"
-          class="w-full text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer"
+          class="w-full text-base sm:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer"
           onclick="toggleWhoDropdown()"
         />
 
         <!-- Dropdown -->
         <div id="whoDropdown"
-             class="absolute top-full left-1/2 -translate-x-1/2 mt-4 w-[500px] rounded-3xl shadow-2xl bg-white z-50 p-6 hidden border border-gray-100">
+             class="absolute top-full left-0 sm:left-1/2 sm:-translate-x-1/2 mt-4 w-full max-w-xs sm:max-w-[500px] rounded-3xl shadow-2xl bg-white z-50 p-6 hidden border border-gray-100">
           <!-- Adults -->
           <div class="flex justify-between items-center py-4">
             <div>
@@ -140,7 +139,7 @@
 
       <!-- Search button -->
       <button type="submit"
-              class="ml-3 md:ml-6 flex items-center justify-center w-14 h-14 rounded-full bg-gold text-white shadow transition hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-gold/30 absolute right-4 md:static md:relative">
+              class="ml-auto sm:ml-3 md:ml-6 flex items-center justify-center w-full sm:w-14 h-12 sm:h-14 rounded-full bg-gold text-white shadow transition hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-gold/30">
         <svg class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <circle cx="11" cy="11" r="8" stroke="currentColor" />
           <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" />
@@ -178,15 +177,15 @@
         data-url="{% url 'properties:property_detail' property.pk %}"
       >
         {% if property.photos.all %}
-          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-48 object-cover">
+          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-40 sm:h-48 object-cover">
         {% else %}
-          <div class="w-full h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-3xl">
+          <div class="w-full h-40 sm:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-3xl">
             No Photo
           </div>
         {% endif %}
-        <div class="p-5 flex-1 flex flex-col">
+        <div class="p-4 sm:p-5 flex-1 flex flex-col">
           <div class="flex items-center justify-between mb-2">
-            <h3 class="text-xl font-bold text-gold">{{ property.name }}</h3>
+            <h3 class="text-lg sm:text-xl font-bold text-gold">{{ property.name }}</h3>
             <span class="text-xs rounded-full px-3 py-1 font-semibold
                 {% if property.property_type == 'short-term' %}bg-[#F7E2BB] text-[#B27D12]{% elif property.property_type == 'long-term' %}bg-[#E7F7BB] text-[#4C8619]{% else %}bg-[#D8E2FF] text-[#2B4172]{% endif %}">
               {{ property.get_property_type_display }}
@@ -198,7 +197,7 @@
             <span>{{ property.bathrooms }} ba</span>
             <span>{{ property.area }} m²</span>
           </div>
-          <div class="text-lg font-extrabold mb-2 text-[#232323]">
+          <div class="text-base sm:text-lg font-extrabold mb-2 text-[#232323]">
             {% if property.property_type == 'short-term' %}
               €{{ property.price_per_night|floatformat:0 }}/night
             {% elif property.property_type == 'long-term' %}
@@ -209,8 +208,8 @@
           </div>
           <div class="text-gray-700 text-sm mb-4 line-clamp-2">{{ property.description }}</div>
           <div class="flex gap-3 mt-auto">
-            <a href="{% url 'properties:property_detail' property.pk %}" class="button-gold w-full text-center flex items-center justify-center font-bold text-lg py-3 transition rounded-lg shadow hover:scale-105">More Info</a>
-            <a href="{% url 'properties:property_detail' property.pk %}#reserve" class="button-gold w-full text-center flex items-center justify-center font-bold text-lg py-3 transition rounded-lg shadow hover:scale-105">Reserve</a>
+            <a href="{% url 'properties:property_detail' property.pk %}" class="button-gold w-full text-center flex items-center justify-center font-bold text-base sm:text-lg py-2 sm:py-3 transition rounded-lg shadow hover:scale-105">More Info</a>
+            <a href="{% url 'properties:property_detail' property.pk %}#reserve" class="button-gold w-full text-center flex items-center justify-center font-bold text-base sm:text-lg py-2 sm:py-3 transition rounded-lg shadow hover:scale-105">Reserve</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make search bar responsive on small screens
- resize calendar and guest dropdowns for mobile
- shrink property card images and text on smaller devices

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_686506f06dd883209dbef034d9825d1b