### PR TITLE
Adjust mobile layout for search and property cards

### DIFF
--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -6,41 +6,41 @@
   {% if filter_type == 'short-term' %}
   <div class="flex justify-center mb-10 px-2">
     <form method="get"
-          class="flex flex-col md:flex-row md:items-center w-full max-w-7xl rounded-3xl md:rounded-full bg-white border border-gray-200 shadow-lg p-2 md:px-8 md:py-4 relative gap-2">
+          class="flex flex-col sm:flex-row sm:items-center w-full max-w-7xl rounded-3xl sm:rounded-full bg-white border border-gray-200 shadow-lg p-2 sm:px-6 sm:py-3 md:px-8 md:py-4 relative gap-2">
       <!-- Where -->
-      <div id="whereField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="whereField" class="search-field flex-1 flex flex-col justify-center p-2 sm:p-0 rounded-xl sm:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Where</span>
         <input type="text"
                name="q"
                value="{{ request.GET.q|default_if_none:'' }}"
                placeholder="Search destinations"
-               class="w-full text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400" />
+               class="w-full text-sm sm:text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400" />
       </div>
       <!-- Divider -->
-      <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
+      <div class="h-px w-full sm:h-10 sm:w-px bg-gray-200"></div>
 
       <!-- Check in -->
-      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center p-2 sm:p-0 rounded-xl sm:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar('checkin')"
-               class="w-full text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
+               class="w-full text-sm sm:text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
       </div>
       <!-- Divider -->
-      <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
+      <div class="h-px w-full sm:h-10 sm:w-px bg-gray-200"></div>
 
       <!-- Check out -->
-      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center p-2 sm:p-0 rounded-xl sm:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
                placeholder="Add dates"
                readonly
                onclick="toggleCalendar('checkout')"
-               class="w-full text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
+               class="w-full text-sm sm:text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer" />
       </div>
 
       <!-- Calendar dropdown -->
@@ -63,12 +63,12 @@
       </div>
 
       <!-- Divider for Who field on mobile, Search button on desktop -->
-      <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
+      <div class="h-px w-full sm:h-10 sm:w-px bg-gray-200"></div>
 
       <!-- Flex container for Who field and Search button to align them on desktop -->
-      <div class="flex flex-row items-center justify-between md:justify-center md:flex-1 gap-2 p-1 md:p-0">
+      <div class="flex flex-row items-center justify-between sm:justify-center sm:flex-1 gap-2 p-1 sm:p-0">
         <!-- Who -->
-        <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-start p-3 md:p-0 rounded-xl md:rounded-none">
+        <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-start p-2 sm:p-0 rounded-xl sm:rounded-none">
           <span class="text-sm md:text-base font-bold text-[#232323]">Who</span>
           <input
             id="whoInput"
@@ -77,7 +77,7 @@
             readonly
             value="Add guests"
             placeholder="Add guests"
-            class="w-full text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer"
+            class="w-full text-sm sm:text-base md:text-lg bg-transparent border-none focus:outline-none p-0 mt-1 font-normal text-gray-500 placeholder-gray-400 cursor-pointer"
             onclick="toggleWhoDropdown()"
           />
 
@@ -143,7 +143,7 @@
 
         <!-- Search button -->
         <button type="submit"
-                class="flex items-center justify-center w-12 h-12 md:w-14 md:h-14 rounded-full bg-gold text-white shadow transition hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-gold/30 md:static">
+                class="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 rounded-full bg-gold text-white shadow transition hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-gold/30 md:static">
           <svg class="w-6 h-6 md:w-7 md:h-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <circle cx="11" cy="11" r="8" stroke="currentColor" />
             <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" />
@@ -171,7 +171,7 @@
   </div>
 
   <!-- Grid of Property Cards -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 md:gap-8 px-2 md:px-0">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 md:gap-8 px-2 md:px-0">
     {% for property in properties %}
       <div
         class="property-card card-3d bg-white rounded-2xl shadow-xl flex flex-col overflow-hidden border border-gold cursor-pointer"
@@ -182,21 +182,21 @@
         data-url="{% url 'properties:property_detail' property.pk %}"
       >
         {% if property.photos.all %}
-          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-40 sm:h-48 object-cover">
+          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-32 sm:h-40 md:h-48 object-cover">
         {% else %}
-          <div class="w-full h-40 sm:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-2xl sm:text-3xl">
+          <div class="w-full h-32 sm:h-40 md:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-2xl sm:text-3xl">
             No Photo
           </div>
         {% endif %}
-        <div class="p-4 sm:p-5 flex-1 flex flex-col">
+        <div class="p-3 sm:p-4 flex-1 flex flex-col">
           <div class="flex items-center justify-between mb-2">
-            <h3 class="text-lg sm:text-xl font-bold text-gold">{{ property.name }}</h3>
+            <h3 class="text-base sm:text-lg font-bold text-gold">{{ property.name }}</h3>
             <span class="text-xs rounded-full px-2 sm:px-3 py-1 font-semibold
                 {% if property.property_type == 'short-term' %}bg-[#F7E2BB] text-[#B27D12]{% elif property.property_type == 'long-term' %}bg-[#E7F7BB] text-[#4C8619]{% else %}bg-[#D8E2FF] text-[#2B4172]{% endif %}">
               {{ property.get_property_type_display }}
             </span>
           </div>
-          <div class="text-[#232323] font-medium text-sm sm:text-base mb-1 truncate">{{ property.location }}</div>
+          <div class="text-[#232323] font-medium text-xs sm:text-sm mb-1 truncate">{{ property.location }}</div>
           <div class="flex items-center text-gray-600 text-xs gap-2 sm:gap-3 mb-3">
             <span>{{ property.bedrooms }} bd</span>
             <span>{{ property.bathrooms }} ba</span>
@@ -213,8 +213,8 @@
           </div>
           <div class="text-gray-700 text-xs sm:text-sm mb-3 sm:mb-4 line-clamp-2">{{ property.description }}</div>
           <div class="flex flex-col sm:flex-row gap-2 sm:gap-3 mt-auto">
-            <a href="{% url 'properties:property_detail' property.pk %}" class="button-gold w-full text-center flex items-center justify-center font-bold text-sm sm:text-base py-2 sm:py-3 transition rounded-lg shadow hover:scale-105">More Info</a>
-            <a href="{% url 'properties:property_detail' property.pk %}#reserve" class="button-gold w-full text-center flex items-center justify-center font-bold text-sm sm:text-base py-2 sm:py-3 transition rounded-lg shadow hover:scale-105">Reserve</a>
+            <a href="{% url 'properties:property_detail' property.pk %}" class="button-gold w-full text-center flex items-center justify-center font-bold text-sm sm:text-base py-2 sm:py-2.5 transition rounded-lg shadow hover:scale-105">More Info</a>
+            <a href="{% url 'properties:property_detail' property.pk %}#reserve" class="button-gold w-full text-center flex items-center justify-center font-bold text-sm sm:text-base py-2 sm:py-2.5 transition rounded-lg shadow hover:scale-105">Reserve</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make search bar more compact on mobile
- shrink property card content for small screens

## Testing
- `pytest -q`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68650a61629c8320bb024080ce0af1be