### PR TITLE
Improve mobile property list

### DIFF
--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -6,9 +6,9 @@
   {% if filter_type == 'short-term' %}
   <div class="flex justify-center mb-10 px-2">
     <form method="get"
-          class="flex flex-col md:flex-row md:items-center w-full max-w-7xl rounded-3xl md:rounded-full bg-white border border-gray-200 shadow-lg p-2 md:px-8 md:py-4 relative gap-2">
+          class="flex flex-col md:flex-row md:items-center w-full max-w-md sm:max-w-xl md:max-w-7xl rounded-2xl md:rounded-full bg-white border border-gray-200 shadow-lg p-2 md:px-6 md:py-3 relative gap-2">
       <!-- Where -->
-      <div id="whereField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="whereField" class="search-field flex-1 flex flex-col justify-center p-2 md:p-0 rounded-xl md:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Where</span>
         <input type="text"
                name="q"
@@ -20,7 +20,7 @@
       <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
 
       <!-- Check in -->
-      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center p-2 md:p-0 rounded-xl md:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
@@ -33,7 +33,7 @@
       <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
 
       <!-- Check out -->
-      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center p-2 md:p-0 rounded-xl md:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
@@ -66,9 +66,9 @@
       <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
 
       <!-- Flex container for Who field and Search button to align them on desktop -->
-      <div class="flex flex-row items-center justify-between md:justify-center md:flex-1 gap-2 p-1 md:p-0">
+      <div class="flex flex-row items-center justify-between md:justify-center md:flex-1 gap-2 p-0 md:p-0">
         <!-- Who -->
-        <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-start p-3 md:p-0 rounded-xl md:rounded-none">
+        <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-start p-2 md:p-0 rounded-xl md:rounded-none">
           <span class="text-sm md:text-base font-bold text-[#232323]">Who</span>
           <input
             id="whoInput"
@@ -181,14 +181,14 @@
         data-img="{% if property.photos.all %}{{ property.photos.first.image.url }}{% endif %}"
         data-url="{% url 'properties:property_detail' property.pk %}"
       >
-        {% if property.photos.all %}
-          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-40 sm:h-48 object-cover">
-        {% else %}
-          <div class="w-full h-40 sm:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-2xl sm:text-3xl">
-            No Photo
-          </div>
-        {% endif %}
-        <div class="p-4 sm:p-5 flex-1 flex flex-col">
+          {% if property.photos.all %}
+            <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-32 sm:h-40 md:h-48 object-cover">
+          {% else %}
+            <div class="w-full h-32 sm:h-40 md:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-2xl sm:text-3xl">
+              No Photo
+            </div>
+          {% endif %}
+          <div class="p-3 sm:p-5 flex-1 flex flex-col">
           <div class="flex items-center justify-between mb-2">
             <h3 class="text-lg sm:text-xl font-bold text-gold">{{ property.name }}</h3>
             <span class="text-xs rounded-full px-2 sm:px-3 py-1 font-semibold


### PR DESCRIPTION
## Summary
- shrink search bar width and paddings on mobile
- reduce card image and padding for compact view

## Testing
- `python manage.py check`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68650a61629c8320bb024080ce0af1be