### PR TITLE
Improve mobile styling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -269,3 +269,12 @@ a:hover, .hover\:text-gold:hover {
 #photoGallery div{ transition: transform 150ms ease; }
 #photoGallery div.drag-target{ border:2px dashed var(--gip-gold); }
 #photoModal:not(.hidden){ display:flex; }
+/* --- Mobile layout adjustments --- */
+@media (max-width: 639px) {
+  /* search bar tweaks */
+  form.search-bar { display: flex; flex-wrap: wrap; }
+  form.search-bar .search-field { flex: 1 1 45%; padding: 0.5rem; }
+  form.search-bar button[type="submit"] { flex-basis: 100%; margin-top: 0.5rem; }
+  /* smaller property card images */
+  .property-card img { height: 8rem; }
+}

--- a/templates/properties/property_list.html
+++ b/templates/properties/property_list.html
@@ -6,9 +6,9 @@
   {% if filter_type == 'short-term' %}
   <div class="flex justify-center mb-10 px-2">
     <form method="get"
-          class="flex flex-col md:flex-row md:items-center w-full max-w-7xl rounded-3xl md:rounded-full bg-white border border-gray-200 shadow-lg p-2 md:px-8 md:py-4 relative gap-2">
+          class="search-bar flex flex-col sm:flex-row sm:items-center w-full max-w-7xl rounded-2xl sm:rounded-full bg-white border border-gray-200 shadow-lg p-2 sm:px-6 sm:py-4 relative gap-2">
       <!-- Where -->
-      <div id="whereField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="whereField" class="search-field flex-1 flex flex-col justify-center p-2 sm:p-0 rounded-xl sm:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Where</span>
         <input type="text"
                name="q"
@@ -20,7 +20,7 @@
       <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
 
       <!-- Check in -->
-      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="checkinField" class="search-field flex-1 flex flex-col justify-center p-2 sm:p-0 rounded-xl sm:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Check in</span>
         <input type="text"
                name="checkin"
@@ -33,7 +33,7 @@
       <div class="h-px w-full md:h-10 md:w-px bg-gray-200"></div>
 
       <!-- Check out -->
-      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center p-3 md:p-0 rounded-xl md:rounded-none">
+      <div id="checkoutField" class="search-field flex-1 flex flex-col justify-center p-2 sm:p-0 rounded-xl sm:rounded-none">
         <span class="text-sm md:text-base font-bold text-[#232323]">Check out</span>
         <input type="text"
                name="checkout"
@@ -68,7 +68,7 @@
       <!-- Flex container for Who field and Search button to align them on desktop -->
       <div class="flex flex-row items-center justify-between md:justify-center md:flex-1 gap-2 p-1 md:p-0">
         <!-- Who -->
-        <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-start p-3 md:p-0 rounded-xl md:rounded-none">
+        <div id="whoField" class="search-field relative flex-1 flex flex-col justify-center items-start p-2 sm:p-0 rounded-xl sm:rounded-none">
           <span class="text-sm md:text-base font-bold text-[#232323]">Who</span>
           <input
             id="whoInput"
@@ -182,9 +182,9 @@
         data-url="{% url 'properties:property_detail' property.pk %}"
       >
         {% if property.photos.all %}
-          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-40 sm:h-48 object-cover">
+          <img src="{{ property.photos.first.image.url }}" alt="{{ property.name }}" class="w-full h-32 sm:h-48 object-cover">
         {% else %}
-          <div class="w-full h-40 sm:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-2xl sm:text-3xl">
+          <div class="w-full h-32 sm:h-48 flex items-center justify-center bg-[#EEE8DC] text-gold font-bold text-2xl sm:text-3xl">
             No Photo
           </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- reduce search bar size on mobile
- shrink property card images on small screens

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68650a61629c8320bb024080ce0af1be