### PR TITLE
Fix calendar timezone issue and update date format

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -180,7 +180,7 @@ function renderCalendar(){
       if(!startDate || (startDate && endDate)){
         startDate = iso;
         endDate   = null;
-      }else if(new Date(iso) >= new Date(startDate)){
+      }else if(parseLocalDate(iso) >= parseLocalDate(startDate)){
         endDate = iso;
       }else{
         startDate = iso;
@@ -192,12 +192,18 @@ function renderCalendar(){
   highlightSelection();
 }
 
+// parse an ISO date string (YYYY-MM-DD) as local time to avoid timezone shifts
+function parseLocalDate(iso){
+  const [y,m,d] = iso.split('-').map(Number);
+  return new Date(y, m-1, d);
+}
+
 function highlightSelection(){
-  const start = startDate ? new Date(startDate) : null;
-  const end   = endDate ? new Date(endDate) : null;
+  const start = startDate ? parseLocalDate(startDate) : null;
+  const end   = endDate ? parseLocalDate(endDate) : null;
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    const d = new Date(btn.dataset.date);
+    const d = parseLocalDate(btn.dataset.date);
     btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
@@ -213,8 +219,9 @@ function highlightSelection(){
     }
   });
 
-  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
-  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  const formatOpts = { day: 'numeric', month: 'long', year: 'numeric' };
+  checkInInput.value  = start ? start.toLocaleDateString('en-GB', formatOpts) : 'Add dates';
+  checkOutInput.value = end ? end.toLocaleDateString('en-GB', formatOpts) : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
 
@@ -342,7 +349,7 @@ document.addEventListener('DOMContentLoaded', () => {
       selEnd = null;
     } else if (selStart && !selEnd) {
       // choosing an end date or restarting start earlier in time
-      if (new Date(iso) >= new Date(selStart)) {
+      if (parseLocalDate(iso) >= parseLocalDate(selStart)) {
         selEnd = iso;
       } else {
         selStart = iso;


### PR DESCRIPTION
## Summary
- handle date strings as local time to avoid off-by-one errors
- display calendar selections in long-form `1 July 2025` format

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68652cc911e483208d1aa04cc8e84264