### PR TITLE
Fix date handling in search calendar

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -142,6 +142,19 @@ const monthNamesFull = ['January','February','March','April','May','June','July'
                         'August','September','October','November','December'];
 const weekDays = ['S','M','T','W','T','F','S'];
 
+function toIso(y, m, d){
+  return `${y}-${String(m+1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+}
+
+function parseIsoLocal(iso){
+  const [yy, mm, dd] = iso.split('-').map(Number);
+  return new Date(yy, mm - 1, dd);
+}
+
+function formatLongDate(dt){
+  return dt.toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
 function createMonthGrid(dateObj){
   const y = dateObj.getFullYear();
   const m = dateObj.getMonth();
@@ -156,7 +169,7 @@ function createMonthGrid(dateObj){
   for(let b=0;b<startWeekD;b++){ html += '<div></div>'; }
   // days
   for(let d=1; d<=daysInMon; d++){
-    const iso = new Date(y,m,d).toISOString().split('T')[0];
+    const iso = toIso(y, m, d);
     html += `<button type="button" data-date="${iso}">${d}</button>`;
   }
   html += '</div></div>';
@@ -180,7 +193,7 @@ function renderCalendar(){
       if(!startDate || (startDate && endDate)){
         startDate = iso;
         endDate   = null;
-      }else if(new Date(iso) >= new Date(startDate)){
+      }else if(parseIsoLocal(iso) >= parseIsoLocal(startDate)){
         endDate = iso;
       }else{
         startDate = iso;
@@ -193,11 +206,11 @@ function renderCalendar(){
 }
 
 function highlightSelection(){
-  const start = startDate ? new Date(startDate) : null;
-  const end   = endDate ? new Date(endDate) : null;
+  const start = startDate ? parseIsoLocal(startDate) : null;
+  const end   = endDate ? parseIsoLocal(endDate) : null;
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    const d = new Date(btn.dataset.date);
+    const d = parseIsoLocal(btn.dataset.date);
     btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
@@ -213,8 +226,8 @@ function highlightSelection(){
     }
   });
 
-  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
-  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  checkInInput.value  = start ? formatLongDate(start) : 'Add dates';
+  checkOutInput.value = end ? formatLongDate(end) : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
 
@@ -292,7 +305,7 @@ document.addEventListener('DOMContentLoaded', () => {
     wNames.forEach(d=> html += `<div class="text-xs font-medium text-center text-gray-400">${d}</div>`);
     for(let b=0;b<lead;b++) html += '<div></div>';
     for(let d=1;d<=days;d++){
-      const iso = new Date(y,m,d).toISOString().split('T')[0];
+      const iso = toIso(y, m, d);
       const dis = isBlocked(iso);
       html += `<button data-date="${iso}" ${dis?'disabled':''}
                class="h-14 w-14 flex items-center justify-center rounded text-[#232323] text-base
@@ -342,7 +355,7 @@ document.addEventListener('DOMContentLoaded', () => {
       selEnd = null;
     } else if (selStart && !selEnd) {
       // choosing an end date or restarting start earlier in time
-      if (new Date(iso) >= new Date(selStart)) {
+      if (parseIsoLocal(iso) >= parseIsoLocal(selStart)) {
         selEnd = iso;
       } else {
         selStart = iso;


### PR DESCRIPTION
## Summary
- ensure calendar dates use local timezone when selecting days
- show long date string format in search inputs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68652cc911e483208d1aa04cc8e84264