### PR TITLE
Fix date selection display in calendar

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -192,12 +192,21 @@ function renderCalendar(){
   highlightSelection();
 }
 
+function parseISODate(iso){
+  const [y,m,d] = iso.split('-').map(Number);
+  return new Date(y, m-1, d);
+}
+
+function formatDisplayDate(date){
+  return date.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'});
+}
+
 function highlightSelection(){
-  const start = startDate ? new Date(startDate) : null;
-  const end   = endDate ? new Date(endDate) : null;
+  const start = startDate ? parseISODate(startDate) : null;
+  const end   = endDate ? parseISODate(endDate) : null;
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    const d = new Date(btn.dataset.date);
+    const d = parseISODate(btn.dataset.date);
     btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
@@ -213,8 +222,8 @@ function highlightSelection(){
     }
   });
 
-  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
-  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  checkInInput.value  = start ? formatDisplayDate(start) : 'Add dates';
+  checkOutInput.value = end ? formatDisplayDate(end) : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
 


### PR DESCRIPTION
## Summary
- parse selected calendar dates as local to avoid timezone shifts
- display dates in search fields in `1 July 2025` style

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686533d513bc832084576af28d53323b