### PR TITLE
Fix date picker timezone issue and update format

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -142,6 +142,25 @@ const monthNamesFull = ['January','February','March','April','May','June','July'
                         'August','September','October','November','December'];
 const weekDays = ['S','M','T','W','T','F','S'];
 
+function pad(n){
+  return String(n).padStart(2, '0');
+}
+
+function isoDate(y, m, d){
+  return `${y}-${pad(m+1)}-${pad(d)}`;
+}
+
+function parseISODate(str){
+  const [y,m,d] = str.split('-').map(Number);
+  return new Date(y, m-1, d);
+}
+
+function formatDisplay(date){
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric', month: 'long', year: 'numeric'
+  });
+}
+
 function createMonthGrid(dateObj){
   const y = dateObj.getFullYear();
   const m = dateObj.getMonth();
@@ -156,7 +175,7 @@ function createMonthGrid(dateObj){
   for(let b=0;b<startWeekD;b++){ html += '<div></div>'; }
   // days
   for(let d=1; d<=daysInMon; d++){
-    const iso = new Date(y,m,d).toISOString().split('T')[0];
+    const iso = isoDate(y,m,d);
     html += `<button type="button" data-date="${iso}">${d}</button>`;
   }
   html += '</div></div>';
@@ -180,7 +199,7 @@ function renderCalendar(){
       if(!startDate || (startDate && endDate)){
         startDate = iso;
         endDate   = null;
-      }else if(new Date(iso) >= new Date(startDate)){
+      }else if(parseISODate(iso) >= parseISODate(startDate)){
         endDate = iso;
       }else{
         startDate = iso;
@@ -193,11 +212,11 @@ function renderCalendar(){
 }
 
 function highlightSelection(){
-  const start = startDate ? new Date(startDate) : null;
-  const end   = endDate ? new Date(endDate) : null;
+  const start = startDate ? parseISODate(startDate) : null;
+  const end   = endDate ? parseISODate(endDate) : null;
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    const d = new Date(btn.dataset.date);
+    const d = parseISODate(btn.dataset.date);
     btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
@@ -213,8 +232,8 @@ function highlightSelection(){
     }
   });
 
-  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
-  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  checkInInput.value  = start ? formatDisplay(start) : 'Add dates';
+  checkOutInput.value = end ? formatDisplay(end) : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
 
@@ -292,7 +311,7 @@ document.addEventListener('DOMContentLoaded', () => {
     wNames.forEach(d=> html += `<div class="text-xs font-medium text-center text-gray-400">${d}</div>`);
     for(let b=0;b<lead;b++) html += '<div></div>';
     for(let d=1;d<=days;d++){
-      const iso = new Date(y,m,d).toISOString().split('T')[0];
+      const iso = isoDate(y,m,d);
       const dis = isBlocked(iso);
       html += `<button data-date="${iso}" ${dis?'disabled':''}
                class="h-14 w-14 flex items-center justify-center rounded text-[#232323] text-base
@@ -329,7 +348,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('detailSelected').textContent =
-      selStart && selEnd ? `${selStart} – ${selEnd}` : '';
+      selStart && selEnd
+        ? `${formatDisplay(parseISODate(selStart))} – ${formatDisplay(parseISODate(selEnd))}`
+        : '';
   }
 
   grid.addEventListener('click', e => {
@@ -342,7 +363,7 @@ document.addEventListener('DOMContentLoaded', () => {
       selEnd = null;
     } else if (selStart && !selEnd) {
       // choosing an end date or restarting start earlier in time
-      if (new Date(iso) >= new Date(selStart)) {
+      if (parseISODate(iso) >= parseISODate(selStart)) {
         selEnd = iso;
       } else {
         selStart = iso;

--- a/templates/properties/property_detail.html
+++ b/templates/properties/property_detail.html
@@ -191,8 +191,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // Find highlighted buttons for range
     const s = calGrid.querySelector('button.range-start');
     const e = calGrid.querySelector('button.range-end');
-    inBox.value = s ? s.dataset.date : '';
-    outBox.value = e ? e.dataset.date : '';
+    inBox.value = s ? formatDisplay(parseISODate(s.dataset.date)) : '';
+    outBox.value = e ? formatDisplay(parseISODate(e.dataset.date)) : '';
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- prevent timezone offsets when generating date strings
- format selected dates as `1 July 2025`
- update property detail auto-fill script to use same formatter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865344ccb9083209e27f7ea49dcfe37