### PR TITLE
Fix calendar date handling

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -142,6 +142,15 @@ const monthNamesFull = ['January','February','March','April','May','June','July'
                         'August','September','October','November','December'];
 const weekDays = ['S','M','T','W','T','F','S'];
 
+function parseISODate(iso){
+  const [y,m,d] = iso.split('-').map(Number);
+  return new Date(y, m-1, d);
+}
+
+function formatDate(dt){
+  return `${dt.getDate()} ${monthNamesFull[dt.getMonth()]} ${dt.getFullYear()}`;
+}
+
 function createMonthGrid(dateObj){
   const y = dateObj.getFullYear();
   const m = dateObj.getMonth();
@@ -180,7 +189,7 @@ function renderCalendar(){
       if(!startDate || (startDate && endDate)){
         startDate = iso;
         endDate   = null;
-      }else if(new Date(iso) >= new Date(startDate)){
+      }else if(parseISODate(iso) >= parseISODate(startDate)){
         endDate = iso;
       }else{
         startDate = iso;
@@ -193,11 +202,11 @@ function renderCalendar(){
 }
 
 function highlightSelection(){
-  const start = startDate ? new Date(startDate) : null;
-  const end   = endDate ? new Date(endDate) : null;
+  const start = startDate ? parseISODate(startDate) : null;
+  const end   = endDate ? parseISODate(endDate) : null;
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    const d = new Date(btn.dataset.date);
+    const d = parseISODate(btn.dataset.date);
     btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
@@ -213,8 +222,8 @@ function highlightSelection(){
     }
   });
 
-  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
-  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  checkInInput.value  = start ? formatDate(start) : 'Add dates';
+  checkOutInput.value = end ? formatDate(end) : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
 
@@ -342,7 +351,7 @@ document.addEventListener('DOMContentLoaded', () => {
       selEnd = null;
     } else if (selStart && !selEnd) {
       // choosing an end date or restarting start earlier in time
-      if (new Date(iso) >= new Date(selStart)) {
+      if (parseISODate(iso) >= parseISODate(selStart)) {
         selEnd = iso;
       } else {
         selStart = iso;


### PR DESCRIPTION
## Summary
- ensure calendar date parsing uses local timezone
- show formatted dates like `1 July 2025`
- adjust property detail date selection logic

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6865344ccb9083209e27f7ea49dcfe37