### PR TITLE
Fix calendar date offset and display format

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -142,6 +142,15 @@ const monthNamesFull = ['January','February','March','April','May','June','July'
                         'August','September','October','November','December'];
 const weekDays = ['S','M','T','W','T','F','S'];
 
+function parseLocalDate(iso){
+  const [y,m,d] = iso.split('-').map(Number);
+  return new Date(y, m-1, d); // local midnight
+}
+
+function formatDisplayDate(date){
+  return date.toLocaleDateString('en-GB', { day:'numeric', month:'long', year:'numeric' });
+}
+
 function createMonthGrid(dateObj){
   const y = dateObj.getFullYear();
   const m = dateObj.getMonth();
@@ -180,7 +189,7 @@ function renderCalendar(){
       if(!startDate || (startDate && endDate)){
         startDate = iso;
         endDate   = null;
-      }else if(new Date(iso) >= new Date(startDate)){
+      }else if(parseLocalDate(iso) >= parseLocalDate(startDate)){
         endDate = iso;
       }else{
         startDate = iso;
@@ -193,11 +202,11 @@ function renderCalendar(){
 }
 
 function highlightSelection(){
-  const start = startDate ? new Date(startDate) : null;
-  const end   = endDate ? new Date(endDate) : null;
+  const start = startDate ? parseLocalDate(startDate) : null;
+  const end   = endDate ? parseLocalDate(endDate) : null;
 
   calGrid.querySelectorAll('button[data-date]').forEach(btn=>{
-    const d = new Date(btn.dataset.date);
+    const d = parseLocalDate(btn.dataset.date);
     btn.classList.remove('range-start','range-end','in-range','no-after');
 
     if(start && btn.dataset.date===startDate){
@@ -213,8 +222,8 @@ function highlightSelection(){
     }
   });
 
-  checkInInput.value  = start ? start.toLocaleDateString() : 'Add dates';
-  checkOutInput.value = end ? end.toLocaleDateString() : 'Add dates';
+  checkInInput.value  = start ? formatDisplayDate(start) : 'Add dates';
+  checkOutInput.value = end ? formatDisplayDate(end) : 'Add dates';
   calDropdown.dataset.start = startDate || '';
   calDropdown.dataset.end   = endDate || '';
 


### PR DESCRIPTION
## Summary
- fix off-by-one error when selecting check-in and check-out dates
- show selected dates in a long format

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6865344ccb9083209e27f7ea49dcfe37